### PR TITLE
v0.9.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -89,4 +89,11 @@ v0.9.0 Added multithreading so that endpoints don't have to wait for others to
         finish. Added function to check Dynafed's connection stats from memcache
         in order to flag endpoints that are offline and skip them from checks.
 v0.9.1 Added verbose option to print on sterr logger events.
-v0.9.2 Added flexibility to the "check" variable to allow bypassing for invalidsettings in config files.
+v0.9.2 Added flexibility to the "check" variable to allow bypassing for invalid
+       settings in config files.
+v0.9.3 Revamped the exception handling and loggers in order to remove the
+       "mlogger" while keeping a consistent format on error reporting and removing
+       the necessity to instantiate a second logger. This also facilitates
+       flexibility for exception handling so these can be removed from levels
+       where it does not belong (before it was used for logging as well and that
+       was a bad design.)

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -195,16 +195,18 @@ class UGRBaseException(Exception):
     """
     Base exception class for dynafed_storagestats module.
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="ERROR", status_code="000", message=None, debug=None):
+        self.error_code = "[%s][%s]" %(error, status_code)
         if message is None:
             # Set some default useful error message
-            self.message = "[ERROR] An unkown exception occured processing"
+            self.message = self.error_code + "An unkown exception occured processing"
         else:
-            self.message = message
+            self.message = self.error_code + message
         if debug is None:
-            self.debug = message
+            self.debug = self.message
         else:
-            self.debug = message + ' ' + debug
+            self.debug = self.message + ' ' + debug
+
         super(UGRBaseException, self).__init__(self.message)
 
 ### Defining Error Exception Classes
@@ -213,38 +215,39 @@ class UGRBaseError(UGRBaseException):
     Base error exception Subclass which will add the [ERROR] tag to all error
     subclasses.
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="ERROR", status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
-            self.message = "[ERROR][000] A unkown error occured."
+            self.message = "A unkown error occured."
         else:
             self.message = message
         self.debug = debug
-        super(UGRBaseError, self).__init__(message=self.message, debug=self.debug)
+
+        super(UGRBaseError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRConfigFileError(UGRBaseError):
     """
     Base error exception subclass for anything relating to the config file(s).
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="ConfigFileError", status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
-            self.message = "[ConfigFileError][000] An unkown error occured reading a configuration file."
+            self.message = "An unkown error occured reading a configuration file."
         else:
             self.message = message
         self.debug = debug
-        super(UGRConfigFileError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRConfigFileError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRUnsupportedPluginError(UGRConfigFileError):
     """
     Exception error when an endpoint of an unsuprted type/protocol plugin
     is detected.
     """
-    def __init__(self, error=None, status_code="000", plugin=None, debug=None):
-        self.message = '[%s][%s] StorageStats method for "%s" not implemented yet.' \
-                       % (error, status_code, plugin)
+    def __init__(self, error="UnsupportedPlugin", status_code="000", plugin=None, debug=None):
+        self.message = 'StorageStats method for "%s" not implemented yet.' \
+                       % (plugin)
         self.debug = debug
-        super(UGRUnsupportedPluginError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRUnsupportedPluginError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRConfigFileErrorIDMismatch(UGRConfigFileError):
     """
@@ -252,10 +255,10 @@ class UGRConfigFileErrorIDMismatch(UGRConfigFileError):
     endpoint does not match the given endpoint ID. Usually a typo.
     """
     def __init__(self, line, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] Failed to match ID in line "%s". Check your configuration.' \
-                       % (error, status_code, line)
+        self.message = 'Failed to match ID in line "%s". Check your configuration.' \
+                       % (line)
         self.debug = debug
-        super(UGRConfigFileErrorIDMismatch, self).__init__(message=self.message, debug=self.debug)
+        super(UGRConfigFileErrorIDMismatch, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRConfigFileErrorMissingRequiredSetting(UGRConfigFileError):
     """
@@ -263,10 +266,10 @@ class UGRConfigFileErrorMissingRequiredSetting(UGRConfigFileError):
     Stats is missing from the config files for the endpoint being processed.
     """
     def __init__(self, setting, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] "%s" is required. Check your configuration.' \
-                  % (error, status_code, setting)
+        self.message = '"%s" is required. Check your configuration.' \
+                  % (setting)
         self.debug = debug
-        super(UGRConfigFileErrorMissingRequiredSetting, self).__init__(message=self.message, debug=self.debug)
+        super(UGRConfigFileErrorMissingRequiredSetting, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRConfigFileErrorInvalidSetting(UGRConfigFileError):
     """
@@ -274,23 +277,23 @@ class UGRConfigFileErrorInvalidSetting(UGRConfigFileError):
     does not match the 'valid' values specified in the 'validators' attribute.
     """
     def __init__(self, setting, valid_plugin_settings, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] Incorrect value given in setting "%s". Valid plugin_settings: %s' \
-                  % (error, status_code, setting, valid_plugin_settings)
+        self.message = 'Incorrect value given in setting "%s". Valid plugin_settings: %s' \
+                  % (setting, valid_plugin_settings)
         self.debug = debug
-        super(UGRConfigFileErrorInvalidSetting, self).__init__(message=self.message, debug=self.debug)
+        super(UGRConfigFileErrorInvalidSetting, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRMemcachedError(UGRBaseError):
     """
     Base error exception subclass for issues deailng with memcached
     communication.
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="MemcachedError", status_code="000", message=None, debug=None):
         if message is None:
-            self.message = '[MemcachedError][000] Unknown memcached error.'
+            self.message = 'Unknown memcached error.'
         else:
             self.message = message
         self.debug = debug
-        super(UGRMemcachedError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRMemcachedError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRMemcachedConnectionError(UGRMemcachedError):
     """
@@ -298,84 +301,81 @@ class UGRMemcachedConnectionError(UGRMemcachedError):
     requested.
     """
     def __init__(self, error=None, status_code="400", debug=None):
-        self.message = '[%s][%s] Failed to connect to memcached.' \
-                       % (error, status_code)
+        self.message = 'Failed to connect to memcached.'
         self.debug = debug
-        super(UGRMemcachedConnectionError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRMemcachedConnectionError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRMemcachedIndexError(UGRMemcachedError):
     """
     Exception error when the requested index in memcached cannot be found.
     """
     def __init__(self, error=None, status_code="404", debug=None):
-        self.message = '[%s][%s] Unable to get memcached index contents.' \
-                       % (error, status_code)
+        self.message = 'Unable to get memcached index contents.'
         self.debug = debug
-        super(UGRMemcachedIndexError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRMemcachedIndexError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsError(UGRBaseError):
     """
     Base error exception subclass for issues deailng when failing to obtain
     the endpoint's storage stats.
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="StorageStatsError", status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
-            self.message = "[StorageStatsError][000] An unkown error occured obtaning storage stats."
+            self.message = "An unkown error occured obtaning storage stats."
         else:
             self.message = message
         self.debug = debug
-        super(UGRStorageStatsError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsConnectionError(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to the endpoint's URN.
     """
     def __init__(self, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] Failed to establish a connection.' \
-                       % (error, status_code)
+        self.message = 'Failed to establish a connection.'
         self.debug = debug
-        super(UGRStorageStatsConnectionError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsConnectionError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsConnectionErrorInvalidSchema(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to an S3 endpoint's API.
     """
     def __init__(self, error=None, status_code="000", schema=None, debug=None):
-        self.message = '[%s][%s] Invalid schema "%s".' \
-                  % (error, status_code, schema)
+        self.message = 'Invalid schema "%s".' \
+                  % (schema)
         self.debug = debug
-        super(UGRStorageStatsConnectionErrorInvalidSchema, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsConnectionErrorInvalidSchema, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsConnectionErrorAzureAPI(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to an S3 endpoint's API.
     """
     def __init__(self, error=None, status_code="000", api=None, debug=None):
-        self.message = '[%s][%s] Error requesting stats using API "%s".' \
-                  % (error, status_code, api)
+        self.message = 'Error requesting stats using API "%s".' \
+                  % (api)
         self.debug = debug
-        super(UGRStorageStatsConnectionErrorAzureAPI, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsConnectionErrorAzureAPI, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsErrorAzureContainerNotFound(UGRStorageStatsError):
     """
     Exception error when no bucket usage stats could be found.
     """
     def __init__(self, error=None, status_code="000", debug=None, container=''):
-        self.message = '[%s][%s] Container tried: %s' \
-                  % (error, status_code, container)
+        self.message = 'Container tried: %s' \
+                  % (container)
         self.debug = debug
-        super(UGRStorageStatsErrorAzureContainerNotFound, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsErrorAzureContainerNotFound, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsConnectionErrorS3API(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to an S3 endpoint's API.
     """
     def __init__(self, error=None, status_code="000", api=None, debug=None):
-        self.message = '[%s][%s] Error requesting stats using API "%s".' \
-                  % (error, status_code, api)
+        self.message = 'Error requesting stats using API "%s".' \
+                  % (api)
         self.debug = debug
-        super(UGRStorageStatsConnectionErrorS3API, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsConnectionErrorS3API, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsOfflineEndpointError(UGRStorageStatsError):
     """
@@ -383,30 +383,27 @@ class UGRStorageStatsOfflineEndpointError(UGRStorageStatsError):
     by Dynafed's connection status check..
     """
     def __init__(self, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] Dynafed has flagged this endpoint as offline.' \
-                       % (error, status_code)
+        self.message = 'Dynafed has flagged this endpoint as offline.'
         self.debug = debug
-        super(UGRStorageStatsOfflineEndpointError, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsOfflineEndpointError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsErrorS3MissingBucketUsage(UGRStorageStatsError):
     """
     Exception error when no bucket usage stats could be found.
     """
     def __init__(self, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] Failed to get bucket usage information.' \
-                  % (error, status_code)
+        self.message = '[%s][%s] Failed to get bucket usage information.'
         self.debug = debug
-        super(UGRStorageStatsErrorS3MissingBucketUsage, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsErrorS3MissingBucketUsage, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsErrorDAVQuotaMethod(UGRStorageStatsError):
     """
     Exception error when the DAV endpoint does not support the RFC 4331 method.
     """
     def __init__(self, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] WebDAV Quota Method.' \
-                  % (error, status_code)
+        self.message = 'WebDAV Quota Method.'
         self.debug = debug
-        super(UGRStorageStatsErrorDAVQuotaMethod, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsErrorDAVQuotaMethod, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsConnectionErrorDAVCertPath(UGRStorageStatsError):
     """
@@ -414,10 +411,10 @@ class UGRStorageStatsConnectionErrorDAVCertPath(UGRStorageStatsError):
     as configured in the config files for the endpoint being processed.
     """
     def __init__(self, error=None, status_code="000", certfile=None, debug=None):
-        self.message = '[%s][%s] Invalid client certificate path "%s".' \
-                  % (error, status_code, certfile)
+        self.message = 'Invalid client certificate path "%s".' \
+                  % (certfile)
         self.debug = debug
-        super(UGRStorageStatsConnectionErrorDAVCertPath, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsConnectionErrorDAVCertPath, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 ### Defining Warning Exception Classes
 class UGRBaseWarning(UGRBaseException):
@@ -425,26 +422,27 @@ class UGRBaseWarning(UGRBaseException):
     Base error exception Subclass which will add the [WARN] tag to all warning
     subclasses.
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="WARNING", status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
-            self.message = '[WARNING][000] A unkown error occured.'
+            self.message = 'A unkown warning occured.'
         else:
             self.message = message
         self.debug = debug
-        super(UGRBaseWarning, self).__init__(message=self.message, debug=self.debug)
+
+        super(UGRBaseWarning, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRConfigFileWarning(UGRBaseWarning):
     """
     Base warning exception subclass for anything relating to the config file(s).
     """
-    def __init__(self, message=None, error=None, status_code="000", debug=None):
+    def __init__(self, error=None, status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
-            self.message = '[%s][%s] An unkown error occured reading a configuration file.' \
-                           % (error, status_code)
+            self.message = 'An unkown error occured reading a configuration file.'
         self.debug = debug
-        super(UGRConfigFileWarning, self).__init__(message=self.message, debug=self.debug)
+
+        super(UGRConfigFileWarning, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRConfigFileWarningMissingSetting(UGRConfigFileWarning):
     """
@@ -454,24 +452,24 @@ class UGRConfigFileWarningMissingSetting(UGRConfigFileWarning):
     in this absence.
     """
     def __init__(self, setting, setting_default, error=None, status_code="000", debug=None):
-        self.message = '[%s][%s] Unspecified "%s" setting. Using default value "%s"' \
-                  % (error, status_code, setting, setting_default)
+        self.message = 'Unspecified "%s" setting. Using default value "%s"' \
+                  % (setting, setting_default)
         self.debug = debug
-        super(UGRConfigFileWarningMissingSetting, self).__init__(message=self.message, debug=self.debug)
+        super(UGRConfigFileWarningMissingSetting, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsWarning(UGRBaseWarning):
     """
     Base warning exception subclass for issues deailng when non-critical errors
     are detected when trying to obtain the endpoint's storage stats.
     """
-    def __init__(self, message=None, debug=None):
+    def __init__(self, error="StorageStatsWarning", status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
-            self.message = '[StorageStatsWarning][000] An unkown error occured reading storage stats'
+            self.message = 'An unkown error occured reading storage stats'
         else:
             self.message = message
         self.debug = debug
-        super(UGRStorageStatsWarning, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsWarning, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsQuotaWarning(UGRStorageStatsWarning):
     """
@@ -481,10 +479,9 @@ class UGRStorageStatsQuotaWarning(UGRStorageStatsWarning):
     StorageStats object class's attribute self.stats['quota']
     """
     def __init__(self, error="NoQuotaGiven", status_code="000", debug=None):
-        self.message = '[%s][%s] No quota obtained from API or configuration file. Using default of 1TB' \
-                       % (error, status_code)
+        self.message = 'No quota obtained from API or configuration file. Using default of 1TB'
         self.debug = debug
-        super(UGRStorageStatsQuotaWarning, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsQuotaWarning, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 class UGRStorageStatsCephS3QuotaDisabledWarning(UGRStorageStatsWarning):
     """
@@ -492,10 +489,9 @@ class UGRStorageStatsCephS3QuotaDisabledWarning(UGRStorageStatsWarning):
     that now quota has been enabled for the endpoint bucket.
     """
     def __init__(self, error="BucketQuotaDisabled", status_code="000", debug=None):
-        self.message = '[%s][%s] Bucket quota is disabled. Using default of 1TB' \
-                  % (error, status_code)
+        self.message = 'Bucket quota is disabled. Using default of 1TB'
         self.debug = debug
-        super(UGRStorageStatsCephS3QuotaDisabledWarning, self).__init__(message=self.message, debug=self.debug)
+        super(UGRStorageStatsCephS3QuotaDisabledWarning, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
 #####################

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -160,43 +160,12 @@ options, args = parser.parse_args()
 ## Exception Classes ##
 #######################
 
-### Log Handler Classes
-class TailLogHandler(logging.Handler):
-    """
-    Logger Handler used in conjuction with the TailLogger class which allows
-    to grab log messages genereated by the logging module into variables.
-    """
-    def __init__(self, log_queue):
-        logging.Handler.__init__(self)
-        self.log_queue = log_queue
-
-    def emit(self, record):
-        self.log_queue.append(self.format(record))
-
-
-class TailLogger(object):
-    """
-    Creates Logger with the TailLogHandler and sets how many lines to keep
-    with maxlen.
-    """
-    def __init__(self, maxlen):
-        self._log_queue = collections.deque(maxlen=maxlen)
-        self._log_handler = TailLogHandler(self._log_queue)
-
-    def contents(self):
-        return '\n'.join(self._log_queue)
-
-    @property
-    def log_handler(self):
-        return self._log_handler
-
-### Exception Classes
 class UGRBaseException(Exception):
     """
     Base exception class for dynafed_storagestats module.
     """
     def __init__(self, error="ERROR", status_code="000", message=None, debug=None):
-        self.error_code = "[%s][%s]" %(error, status_code)
+        self.error_code = "[%s][%s] " %(error, status_code)
         if message is None:
             # Set some default useful error message
             self.message = self.error_code + "An unkown exception occured processing"
@@ -1800,13 +1769,13 @@ def get_storagestats(endpoint):
             flogger.info("[%s] Contacting endpoint." % (endpoint.id))
             endpoint.get_storagestats()
         elif endpoint.stats['check'] is "EndpointOffline":
-            flogger.error("[%s][%s]. Bypassing stats check." % (endpoint.id, endpoint.stats['check']))
+            flogger.error("[%s][%s] Bypassing stats check." % (endpoint.id, endpoint.stats['check']))
             raise UGRStorageStatsOfflineEndpointError(
                 status_code="400",
                 error="EndpointOffline"
             )
         else:
-            flogger.error("[%s][%s]. Bypassing stats check." % (endpoint.id, endpoint.stats['check']))
+            flogger.error("[%s][%s] Bypassing stats check." % (endpoint.id, endpoint.stats['check']))
 
     except UGRStorageStatsOfflineEndpointError as ERR:
         flogger.error("[%s]%s" % (endpoint.id, ERR.debug))

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -661,10 +661,6 @@ class StorageStats(object):
             except KeyError:
                 try:
                     if self.validators[ep_setting]['required']:
-                        # Mark endpoint to be skipped with reason.
-                        self.stats['check'] = 'MissingRequiredSetting'
-                        self.plugin_settings.update({ep_setting: ''})
-                        
                         raise UGRConfigFileErrorMissingRequiredSetting(
                             error="MissingRequiredSetting",
                             setting=ep_setting,
@@ -675,13 +671,20 @@ class StorageStats(object):
                             setting=ep_setting,
                             setting_default=self.validators[ep_setting]['default'],
                             )
+                except UGRConfigFileErrorMissingRequiredSetting as ERR:
+                    # Mark endpoint to be skipped with reason.
+                    self.stats['check'] = 'MissingRequiredSetting'
+                    self.plugin_settings.update({ep_setting: ''})
+
+                    flogger.error("[%s]%s" % (self.id, ERR.debug))
+                    self.debug.append(ERR.debug)
+
                 except UGRConfigFileWarningMissingSetting as WARN:
                     # Set the default value for this setting.
                     self.plugin_settings.update({ep_setting: self.validators[ep_setting]['default']})
+
                     flogger.warning("[%s]%s" % (self.id, WARN.debug))
                     self.debug.append(WARN.debug)
-                    self.plugin_settings.update({ep_setting: self.validators[ep_setting]['default']})
-
 
             # If the ep_setting has been defined, check against a list of valid
             # plugin_settings (if defined, otherwise contiune). Also transform to boolean
@@ -880,8 +883,6 @@ class AzureStorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         # First we call the super function to initialize the initial atributes
         # given by the StorageStats class.
@@ -894,18 +895,7 @@ class AzureStorageStats(StorageStats):
         })
 
         # Invoke the validate_plugin_settings() method
-        try:
-            self.validate_plugin_settings()
-        except UGRConfigFileError as ERR:
-            flogger.error("[%s]%s" % (self.id, ERR.debug))
-            mlogger.error("%s" % (ERR.message))
-            self.debug.append(ERR.debug)
-            self.status = ERR.message
-        except UGRConfigFileWarning as WARN:
-            flogger.warning("[%s]%s" % (self.id, WARN.debug))
-            mlogger.warning("%s" % (WARN.message))
-            self.debug.append(WARN.debug)
-            self.status = memcached_logline.contents()
+        self.validate_plugin_settings()
 
         # Invoke the validate_schema() method
         self.validate_schema()
@@ -975,8 +965,6 @@ class S3StorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         super(S3StorageStats, self).__init__(*args, **kwargs)
         self.storageprotocol = "S3"
@@ -1009,18 +997,7 @@ class S3StorageStats(StorageStats):
         })
 
         # Invoke the validate_plugin_settings() method
-        try:
-            self.validate_plugin_settings()
-        except UGRConfigFileError as ERR:
-            flogger.error("[%s]%s" % (self.id, ERR.debug))
-            mlogger.error("%s" % (ERR.message))
-            self.debug.append(ERR.debug)
-            self.status = memcached_logline.contents()
-        except UGRConfigFileWarning as WARN:
-            flogger.warning("[%s]%s" % (self.id, WARN.debug))
-            mlogger.warning("%s" % (WARN.message))
-            self.debug.append(WARN.debug)
-            self.status = memcached_logline.contents()
+        self.validate_plugin_settings()
 
         # Invoke the validate_schema() method
         self.validate_schema()
@@ -1292,8 +1269,6 @@ class DAVStorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         super(DAVStorageStats, self).__init__(*args, **kwargs)
         self.storageprotocol = "DAV"
@@ -1312,18 +1287,7 @@ class DAVStorageStats(StorageStats):
         })
 
         # Invoke the validate_plugin_settings() method
-        try:
-            self.validate_plugin_settings()
-        except UGRConfigFileError as ERR:
-            flogger.error("[%s]%s" % (self.id, ERR.debug))
-            mlogger.error("%s" % (ERR.message))
-            self.debug.append(ERR.debug)
-            self.status = memcached_logline.contents()
-        except UGRConfigFileWarning as WARN:
-            flogger.warning("[%s]%s" % (self.id, WARN.debug))
-            mlogger.warning("%s" % (WARN.message))
-            self.debug.append(WARN.debug)
-            self.status = memcached_logline.contents()
+        self.validate_plugin_settings()
 
         # Invoke the validate_schema() method
         self.validate_schema()

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -14,7 +14,7 @@ Prerequisites:
 """
 from __future__ import print_function
 
-__version__ = "v0.9.2"
+__version__ = "v0.9.3"
 
 import os
 import sys

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -1578,7 +1578,7 @@ def get_endpoints(config_dir="/etc/ugr/conf.d/"):
             flogger.error("[%s]%s" % (endpoints[endpoint]['id'], ERR.debug))
             mlogger.error("%s" % (ERR.message))
             ep = StorageStats(endpoints[endpoint])
-            ep.debug.append(ERR.debug)
+            ep.debug.append("[ERROR]" + ERR.debug)
             ep.status = memcached_logline.contents()
 
         storage_objects.append(ep)

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -881,9 +881,6 @@ class AzureStorageStats(StorageStats):
         Extend or replace any object attributes specific to the type of
         storage endpoint. Below are the most common ones, but add as necessary.
         """
-        ############# Creating loggers ################
-        flogger = logging.getLogger(__name__)
-        ###############################################
         # First we call the super function to initialize the initial atributes
         # given by the StorageStats class.
         super().__init__(*args, **kwargs)
@@ -963,9 +960,6 @@ class S3StorageStats(StorageStats):
         the storage status check can proceed.
         Extend the uri attribute with S3 specific attributes like bucket.
         """
-        ############# Creating loggers ################
-        flogger = logging.getLogger(__name__)
-        ###############################################
         super(S3StorageStats, self).__init__(*args, **kwargs)
         self.storageprotocol = "S3"
         self.validators.update({
@@ -1267,9 +1261,6 @@ class DAVStorageStats(StorageStats):
         Extend the object's validators unique to the storage type to make sure
         the storage status check can proceed.
         """
-        ############# Creating loggers ################
-        flogger = logging.getLogger(__name__)
-        ###############################################
         super(DAVStorageStats, self).__init__(*args, **kwargs)
         self.storageprotocol = "DAV"
         self.validators.update({

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -223,7 +223,7 @@ class UGRConfigFileErrorIDMismatch(UGRConfigFileError):
     Exception error when a line in the configuration file under a specific
     endpoint does not match the given endpoint ID. Usually a typo.
     """
-    def __init__(self, line, error=None, status_code="000", debug=None):
+    def __init__(self, line, error="SettingIDMismatch", status_code="000", debug=None):
         self.message = 'Failed to match ID in line "%s". Check your configuration.' \
                        % (line)
         self.debug = debug
@@ -234,7 +234,7 @@ class UGRConfigFileErrorMissingRequiredSetting(UGRConfigFileError):
     Exception error when an setting required by this module to obtain the Storage
     Stats is missing from the config files for the endpoint being processed.
     """
-    def __init__(self, setting, error=None, status_code="000", debug=None):
+    def __init__(self, setting, error="MissingRequiredSetting", status_code="000", debug=None):
         self.message = '"%s" is required. Check your configuration.' \
                   % (setting)
         self.debug = debug
@@ -245,7 +245,7 @@ class UGRConfigFileErrorInvalidSetting(UGRConfigFileError):
     Exception error when the value given for an setting in the configuration file
     does not match the 'valid' values specified in the 'validators' attribute.
     """
-    def __init__(self, setting, valid_plugin_settings, error=None, status_code="000", debug=None):
+    def __init__(self, setting, valid_plugin_settings, error="InvalidSetting", status_code="000", debug=None):
         self.message = 'Incorrect value given in setting "%s". Valid plugin_settings: %s' \
                   % (setting, valid_plugin_settings)
         self.debug = debug
@@ -269,7 +269,7 @@ class UGRMemcachedConnectionError(UGRMemcachedError):
     Exception error when script cannot connect to a memcached instance as
     requested.
     """
-    def __init__(self, error=None, status_code="400", debug=None):
+    def __init__(self, error="MemcachedConnectionError", status_code="400", debug=None):
         self.message = 'Failed to connect to memcached.'
         self.debug = debug
         super(UGRMemcachedConnectionError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
@@ -278,7 +278,7 @@ class UGRMemcachedIndexError(UGRMemcachedError):
     """
     Exception error when the requested index in memcached cannot be found.
     """
-    def __init__(self, error=None, status_code="404", debug=None):
+    def __init__(self, error="MemcachedEmptyIndex", status_code="404", debug=None):
         self.message = 'Unable to get memcached index contents.'
         self.debug = debug
         super(UGRMemcachedIndexError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
@@ -301,7 +301,7 @@ class UGRStorageStatsConnectionError(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to the endpoint's URN.
     """
-    def __init__(self, error=None, status_code="000", debug=None):
+    def __init__(self, error="ConnectionError", status_code="000", debug=None):
         self.message = 'Failed to establish a connection.'
         self.debug = debug
         super(UGRStorageStatsConnectionError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
@@ -310,7 +310,7 @@ class UGRStorageStatsConnectionErrorInvalidSchema(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to an S3 endpoint's API.
     """
-    def __init__(self, error=None, status_code="000", schema=None, debug=None):
+    def __init__(self, error="InvalidSchema", status_code="000", schema=None, debug=None):
         self.message = 'Invalid schema "%s".' \
                   % (schema)
         self.debug = debug
@@ -320,7 +320,7 @@ class UGRStorageStatsConnectionErrorAzureAPI(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to an S3 endpoint's API.
     """
-    def __init__(self, error=None, status_code="000", api=None, debug=None):
+    def __init__(self, error="ConnectionError", status_code="000", api=None, debug=None):
         self.message = 'Error requesting stats using API "%s".' \
                   % (api)
         self.debug = debug
@@ -330,7 +330,7 @@ class UGRStorageStatsErrorAzureContainerNotFound(UGRStorageStatsError):
     """
     Exception error when no bucket usage stats could be found.
     """
-    def __init__(self, error=None, status_code="000", debug=None, container=''):
+    def __init__(self, error="ContainerNotFound", status_code="000", debug=None, container=''):
         self.message = 'Container tried: %s' \
                   % (container)
         self.debug = debug
@@ -340,7 +340,7 @@ class UGRStorageStatsConnectionErrorS3API(UGRStorageStatsError):
     """
     Exception error when there is an issue connecting to an S3 endpoint's API.
     """
-    def __init__(self, error=None, status_code="000", api=None, debug=None):
+    def __init__(self, error="ConnectionError", status_code="000", api=None, debug=None):
         self.message = 'Error requesting stats using API "%s".' \
                   % (api)
         self.debug = debug
@@ -351,7 +351,7 @@ class UGRStorageStatsOfflineEndpointError(UGRStorageStatsError):
     Exception error when and endpoint is detected to have been flagged as offline
     by Dynafed's connection status check..
     """
-    def __init__(self, error=None, status_code="000", debug=None):
+    def __init__(self, error="EndpointOffline", status_code="000", debug=None):
         self.message = 'Dynafed has flagged this endpoint as offline.'
         self.debug = debug
         super(UGRStorageStatsOfflineEndpointError, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
@@ -360,7 +360,7 @@ class UGRStorageStatsErrorS3MissingBucketUsage(UGRStorageStatsError):
     """
     Exception error when no bucket usage stats could be found.
     """
-    def __init__(self, error=None, status_code="000", debug=None):
+    def __init__(self, error="MissingBucketUsage", status_code="000", debug=None):
         self.message = '[%s][%s] Failed to get bucket usage information.'
         self.debug = debug
         super(UGRStorageStatsErrorS3MissingBucketUsage, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
@@ -369,7 +369,7 @@ class UGRStorageStatsErrorDAVQuotaMethod(UGRStorageStatsError):
     """
     Exception error when the DAV endpoint does not support the RFC 4331 method.
     """
-    def __init__(self, error=None, status_code="000", debug=None):
+    def __init__(self, error="UnsupportedMethod", status_code="000", debug=None):
         self.message = 'WebDAV Quota Method.'
         self.debug = debug
         super(UGRStorageStatsErrorDAVQuotaMethod, self).__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
@@ -379,7 +379,7 @@ class UGRStorageStatsConnectionErrorDAVCertPath(UGRStorageStatsError):
     Exception caused when there is an issue reading a client X509 certificate
     as configured in the config files for the endpoint being processed.
     """
-    def __init__(self, error=None, status_code="000", certfile=None, debug=None):
+    def __init__(self, error="ClientCertError", status_code="000", certfile=None, debug=None):
         self.message = 'Invalid client certificate path "%s".' \
                   % (certfile)
         self.debug = debug
@@ -405,7 +405,7 @@ class UGRConfigFileWarning(UGRBaseWarning):
     """
     Base warning exception subclass for anything relating to the config file(s).
     """
-    def __init__(self, error=None, status_code="000", message=None, debug=None):
+    def __init__(self, error="ConfigFileWarning", status_code="000", message=None, debug=None):
         if message is None:
             # Set some default useful error message
             self.message = 'An unkown error occured reading a configuration file.'
@@ -420,7 +420,7 @@ class UGRConfigFileWarningMissingSetting(UGRConfigFileWarning):
     out the default setting given by the 'validators' attribute that will be used
     in this absence.
     """
-    def __init__(self, setting, setting_default, error=None, status_code="000", debug=None):
+    def __init__(self, setting, setting_default, error="MissingSetting", status_code="000", debug=None):
         self.message = 'Unspecified "%s" setting. Using default value "%s"' \
                   % (setting, setting_default)
         self.debug = debug

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -508,11 +508,7 @@ class StorageStats(object):
     for earch storage endpoint. As well as how to obtain stats and output it.
     """
     def __init__(self, _ep):
-        ############# Creating loggers ################
-        flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
-        ###############################################
+
         self.stats = {
             'bytesused': -1,
             'bytesfree': -1,
@@ -575,8 +571,6 @@ class StorageStats(object):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         memcached_srv = memcached_ip + ':' + memcached_port
         mc = memcache.Client([memcached_srv])
@@ -593,18 +587,12 @@ class StorageStats(object):
         flogger.info("[%s]Uploading stats to memcached server: %s" % (self.id, memcached_srv))
         flogger.debug("[%s]Using memcached index: %s" % (self.id, memcached_index))
         flogger.debug("[%s]String uploading to memcached: %s" % (self.id, storagestats))
-        try:
-            if mc.set(memcached_index, storagestats) == 0:
-                raise UGRMemcachedConnectionError(
-                    status_code="400",
-                    error="MemcachedConnectionError",
-                )
 
-        except UGRMemcachedConnectionError as ERR:
-            flogger.error("[%s]%s" % (self.id, ERR.debug))
-            mlogger.error("%s" % (ERR.message))
-            self.debug.append(ERR.debug)
-            self.status = memcached_logline.contents()
+        if mc.set(memcached_index, storagestats) == 0:
+            raise UGRMemcachedConnectionError(
+                status_code="400",
+                error="MemcachedConnectionError",
+            )
 
     def get_from_memcached(self, memcached_ip='127.0.0.1', memcached_port='11211'):
         """
@@ -660,8 +648,6 @@ class StorageStats(object):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         flogger.info("[%s]Validating configured settings." % (self.id))
         for ep_setting in self.validators:
@@ -673,25 +659,19 @@ class StorageStats(object):
                 self.plugin_settings[ep_setting]
 
             except KeyError:
-                try:
-                    if self.validators[ep_setting]['required']:
-                        self.plugin_settings.update({ep_setting: ''})
-                        raise UGRConfigFileErrorMissingRequiredSetting(
-                            error="MissingRequiredSetting",
-                            setting=ep_setting,
-                            )
-                    else:
-                        raise UGRConfigFileWarningMissingSetting(
-                            error="MissingSetting",
-                            setting=ep_setting,
-                            setting_default=self.validators[ep_setting]['default'],
-                            )
-                except UGRBaseWarning as WARN:
-                    flogger.warning("[%s]%s" % (self.id, WARN.debug))
-                    mlogger.warning("%s" % (WARN.message))
-                    self.debug.append(WARN.debug)
-                    self.status = memcached_logline.contents()
+                if self.validators[ep_setting]['required']:
+                    self.plugin_settings.update({ep_setting: ''})
+                    raise UGRConfigFileErrorMissingRequiredSetting(
+                        error="MissingRequiredSetting",
+                        setting=ep_setting,
+                        )
+                else:
                     self.plugin_settings.update({ep_setting: self.validators[ep_setting]['default']})
+                    raise UGRConfigFileWarningMissingSetting(
+                        error="MissingSetting",
+                        setting=ep_setting,
+                        setting_default=self.validators[ep_setting]['default'],
+                        )
 
             # If the ep_setting has been defined, check against a list of valid
             # plugin_settings (if defined, otherwise contiune). Also transform to boolean
@@ -740,8 +720,6 @@ class StorageStats(object):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         flogger.debug("[%s]Validating URN schema: %s" % (self.id, self.uri['scheme']))
 
@@ -913,6 +891,11 @@ class AzureStorageStats(StorageStats):
             mlogger.error("%s" % (ERR.message))
             self.debug.append(ERR.debug)
             self.status = ERR.message
+        except UGRConfigFileWarning as WARN:
+            flogger.warning("[%s]%s" % (self.id, WARN.debug))
+            mlogger.warning("%s" % (WARN.message))
+            self.debug.append(WARN.debug)
+            self.status = memcached_logline.contents()
 
         # Invoke the validate_schema() method
         self.validate_schema()
@@ -928,8 +911,6 @@ class AzureStorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
 
         if self.plugin_settings['storagestats.api'].lower() == 'generic':
@@ -1025,6 +1006,11 @@ class S3StorageStats(StorageStats):
             mlogger.error("%s" % (ERR.message))
             self.debug.append(ERR.debug)
             self.status = memcached_logline.contents()
+        except UGRConfigFileWarning as WARN:
+            flogger.warning("[%s]%s" % (self.id, WARN.debug))
+            mlogger.warning("%s" % (WARN.message))
+            self.debug.append(WARN.debug)
+            self.status = memcached_logline.contents()
 
         # Invoke the validate_schema() method
         self.validate_schema()
@@ -1043,8 +1029,6 @@ class S3StorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
 
         # Getting the storage Stats CephS3's Admin API
@@ -1266,8 +1250,6 @@ class S3StorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         flogger.debug("[%s]Validating URN schema: %s" % (self.id, self.uri['scheme']))
         if self.uri['scheme'] == 's3':
@@ -1327,6 +1309,11 @@ class DAVStorageStats(StorageStats):
             mlogger.error("%s" % (ERR.message))
             self.debug.append(ERR.debug)
             self.status = memcached_logline.contents()
+        except UGRConfigFileWarning as WARN:
+            flogger.warning("[%s]%s" % (self.id, WARN.debug))
+            mlogger.warning("%s" % (WARN.message))
+            self.debug.append(WARN.debug)
+            self.status = memcached_logline.contents()
 
         # Invoke the validate_schema() method
         self.validate_schema()
@@ -1339,8 +1326,6 @@ class DAVStorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         api_url = '{scheme}://{netloc}{path}'.format(scheme=self.uri['scheme'], netloc=self.uri['netloc'], path=self.uri['path'])
         if self.plugin_settings['storagestats.api'].lower() == 'generic':
@@ -1403,37 +1388,26 @@ class DAVStorageStats(StorageStats):
 
                 elif self.plugin_settings['storagestats.api'].lower() == 'rfc4331':
                     tree = etree.fromstring(response.content)
-                    try:
-                        node = tree.find('.//{DAV:}quota-available-bytes').text
-                        if node is not None:
-                            pass
-                        else:
-                            raise UGRStorageStatsErrorDAVQuotaMethod(
-                                error="UnsupportedMethod"
-                                )
-                    except UGRStorageStatsError as ERR:
-                        flogger.error("[%s]%s" % (self.id, ERR.debug))
-                        mlogger.error("%s" % (ERR.message))
-                        self.stats['bytesused'] = -1
-                        self.stats['bytesfree'] = -1
-                        self.stats['quota'] = -1
-                        self.debug.append(ERR.debug)
-                        self.status = memcached_logline.contents()
+                    node = tree.find('.//{DAV:}quota-available-bytes').text
+                    # Check that we got the requested information. If not, then
+                    # the method is not supported by the endpoint.
+                    if node is None:
+                        raise UGRStorageStatsErrorDAVQuotaMethod(
+                            error="UnsupportedMethod"
+                            )
+                    # Assign the values returned by the endpoint.
+                    self.stats['bytesused'] = int(tree.find('.//{DAV:}quota-used-bytes').text)
+                    self.stats['bytesfree'] = int(tree.find('.//{DAV:}quota-available-bytes').text)
 
+                    # Determine which value to use for the quota.
+                    if self.plugin_settings['storagestats.quota'] == 'api':
+                        # If quota-available-bytes is reported as '0' is because no quota is
+                        # provided, so we use the one from the config file or default.
+                        if self.stats['bytesfree'] != 0:
+                            self.stats['quota'] = self.stats['bytesused'] + self.stats['bytesfree']
                     else:
-                        self.stats['bytesused'] = int(tree.find('.//{DAV:}quota-used-bytes').text)
-                        self.stats['bytesfree'] = int(tree.find('.//{DAV:}quota-available-bytes').text)
-                        if self.plugin_settings['storagestats.quota'] == 'api':
-                            # If quota-available-bytes is reported as '0' is because no quota is
-                            # provided, so we use the one from the config file or default.
-                            if self.stats['bytesfree'] != 0:
-                                self.stats['quota'] = self.stats['bytesused'] + self.stats['bytesfree']
-                        else:
-                            self.stats['quota'] = self.plugin_settings['storagestats.quota']
-            #        except TypeError:
-            #            raise MethodNotSupported(name='free', server=hostname)
-            #        except etree.XMLSyntaxError:
-            #            return str()
+                        self.stats['quota'] = self.plugin_settings['storagestats.quota']
+
             else:
                 raise UGRStorageStatsConnectionError(
                     error='ConnectionError',
@@ -1448,8 +1422,6 @@ class DAVStorageStats(StorageStats):
         """
         ############# Creating loggers ################
         flogger = logging.getLogger(__name__)
-        mlogger = logging.getLogger(__name__+'memcached_logger')
-        # memcached_logline = TailLogger(1)
         ###############################################
         schema_translator = {
             'dav': 'http',
@@ -1479,8 +1451,6 @@ def get_config(config_dir="/etc/ugr/conf.d/"):
     """
     ############# Creating loggers ################
     flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
     ###############################################
     endpoints = {}
     global_settings = {}
@@ -1520,9 +1490,8 @@ def get_config(config_dir="/etc/ugr/conf.d/"):
                                     line=line.split(":")[0],
                                     )
                         except UGRConfigFileError as ERR:
-                            flogger.error("[%s]%s" % (self.id, ERR.debug))
-                            mlogger.error("%s" % (ERR.message))
-                            print(ERR.debug)
+                            flogger.critical("[%s]%s" % (_id, ERR.debug))
+                            print("[CRITICAL][%s]%s" % (_id, ERR.debug))
                             sys.exit(1)
                             # self.debug.append(ERR.debug)
                             # self.status = memcached_logline.contents()
@@ -1545,11 +1514,7 @@ def factory(plugin):
     Return object class to use based on the plugin specified in the UGR's
     configuration files.
     """
-    ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
-    ###############################################
+
     plugin_dict = {
         'libugrlocplugin_dav.so': DAVStorageStats,
         'libugrlocplugin_http.so': DAVStorageStats,
@@ -1573,8 +1538,6 @@ def get_connectionstats(endpoints, memcached_ip='127.0.0.1', memcached_port='112
     """
     ############# Creating loggers ################
     flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
     ###############################################
     # Setup connection to a memcache instance
     memcached_srv = options.memcached_ip + ':' + options.memcached_port
@@ -1602,7 +1565,7 @@ def get_connectionstats(endpoints, memcached_ip='127.0.0.1', memcached_port='112
             )
 
         # Check if we actually got information
-    except UGRMemcachedIndexError as ERR:
+    except UGRMemcachedError as ERR:
         flogger.error("Memcached server %s did not return data. %s" % (memcached_srv, ERR.debug))
     else:
         if isinstance(connection_stats, bytes):
@@ -1667,9 +1630,7 @@ def create_free_space_request_content():
     :return: the XML string of request content.
     """
     ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
+
     ###############################################
     root = etree.Element("propfind", xmlns="DAV:")
     prop = etree.SubElement(root, "prop")
@@ -1686,9 +1647,7 @@ def add_xml_getcontentlength(content):
     total byte count.
     """
     ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
+
     ###############################################
     xml = etree.fromstring(content)
     bytesused = 0
@@ -1704,9 +1663,7 @@ def convert_size_to_bytes(size):
     Converts given sizse into bytes.
     """
     ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
+
     ###############################################
     multipliers = {
         'kib': 1024,
@@ -1740,9 +1697,7 @@ def output_StAR_xml(endpoints, output_dir="/tmp"):
     Create a single StAR XML file for all endpoints passed to this function.
     """
     ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
+
     ###############################################
     SR_namespace = "http://eu-emi.eu/namespaces/2011/02/storagerecord"
     SR = "{%s}" % SR_namespace
@@ -1766,9 +1721,7 @@ def output_json(endpoints, output_dir="/tmp"):
     Create a single json file for all endpoints passed to this function.
     """
     ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
+
     ###############################################
 
     #Create the json structure in python terms
@@ -1817,9 +1770,7 @@ def output_plain(endpoints, output_dir="/tmp"):
     Create a single txt file for all endpoints passed to this function.
     """
     ############# Creating loggers ################
-    flogger = logging.getLogger(__name__)
-    mlogger = logging.getLogger(__name__+'memcached_logger')
-    # memcached_logline = TailLogger(1)
+
     ###############################################
 
     # Initialize total tally
@@ -1961,7 +1912,13 @@ if __name__ == '__main__':
     for endpoint in endpoints:
         # Upload Storagestats into memcached.
         if options.output_memcached:
-            endpoint.upload_to_memcached(options.memcached_ip, options.memcached_port)
+            try:
+                endpoint.upload_to_memcached(options.memcached_ip, options.memcached_port)
+            except UGRMemcachedConnectionError as ERR:
+                flogger.error("[%s]%s" % (endpoint.id, ERR.debug))
+                mlogger.error("%s" % (ERR.message))
+                endpoint.debug.append(ERR.debug)
+                endpoint.status = memcached_logline.contents()
 
         # Print Storagestats to the standard output.
         if options.output_stdout:

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -615,7 +615,7 @@ class StorageStats(object):
         except UGRMemcachedIndexError as ERR:
             flogger.error("[%s]%s" % (self.id, ERR.debug))
             mlogger.error("%s" % (ERR.message))
-            self.debug.append(ERR.debug)
+            self.debug.append("[ERROR]" + ERR.debug)
             self.status = memcached_logline.contents()
             memcached_contents = '%%'.join([
                 self.id,
@@ -673,14 +673,14 @@ class StorageStats(object):
                     self.plugin_settings.update({ep_setting: ''})
 
                     flogger.error("[%s]%s" % (self.id, ERR.debug))
-                    self.debug.append(ERR.debug)
+                    self.debug.append("[ERROR]" + ERR.debug)
 
                 except UGRConfigFileWarningMissingSetting as WARN:
                     # Set the default value for this setting.
                     self.plugin_settings.update({ep_setting: self.validators[ep_setting]['default']})
 
                     flogger.warning("[%s]%s" % (self.id, WARN.debug))
-                    self.debug.append(WARN.debug)
+                    self.debug.append("[WARNING]" + WARN.debug)
 
             # If the ep_setting has been defined, check against a list of valid
             # plugin_settings (if defined, otherwise contiune). Also transform to boolean
@@ -1454,7 +1454,7 @@ def get_config(config_dir="/etc/ugr/conf.d/"):
                             flogger.critical("[%s]%s" % (_id, ERR.debug))
                             print("[CRITICAL][%s]%s" % (_id, ERR.debug))
                             sys.exit(1)
-                            # self.debug.append(ERR.debug)
+                            # self.debug.append("[ERROR]" + ERR.debug)
                             # self.status = memcached_logline.contents()
                     else:
                         # Ignore any other lines
@@ -1832,17 +1832,17 @@ def get_storagestats(endpoint):
     except UGRStorageStatsOfflineEndpointError as ERR:
         flogger.error("[%s]%s" % (endpoint.id, ERR.debug))
         mlogger.error("%s" % (ERR.message))
-        endpoint.debug.append(ERR.debug)
+        endpoint.debug.append("[ERROR]" + ERR.debug)
         endpoint.status = memcached_logline.contents()
     except UGRStorageStatsWarning as WARN:
         flogger.warning("[%s]%s" % (endpoint.id, WARN.debug))
         mlogger.warning("%s" % (WARN.message))
-        endpoint.debug.append(WARN.debug)
+        endpoint.debug.append("[WARNING]" + WARN.debug)
         endpoint.status = memcached_logline.contents()
     except UGRStorageStatsError as ERR:
         flogger.error("[%s]%s" % (endpoint.id, ERR.debug))
         mlogger.error("%s" % (ERR.message))
-        endpoint.debug.append(ERR.debug)
+        endpoint.debug.append("[ERROR]" + ERR.debug)
         endpoint.status = memcached_logline.contents()
 
 
@@ -1878,7 +1878,7 @@ if __name__ == '__main__':
             except UGRMemcachedConnectionError as ERR:
                 flogger.error("[%s]%s" % (endpoint.id, ERR.debug))
                 mlogger.error("%s" % (ERR.message))
-                endpoint.debug.append(ERR.debug)
+                endpoint.debug.append("[ERROR]" + ERR.debug)
                 endpoint.status = memcached_logline.contents()
 
         # Print Storagestats to the standard output.


### PR DESCRIPTION
Revamped the exception handling and loggers in order to remove the "mlogger" while keeping a consistent format on error reporting and removing the necessity to instantiate a second logger. This also facilitates flexibility for exception handling so these can be removed from levels where it does not belong (before it was used for logging as well and that was a bad design.)