### PR TITLE
v0.9.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -96,4 +96,6 @@ v0.9.3 Revamped the exception handling and loggers in order to remove the
        the necessity to instantiate a second logger. This also facilitates
        flexibility for exception handling so these can be removed from levels
        where it does not belong (before it was used for logging as well and that
-       was a bad design.)
+       was a bad design.) Removed error message from memcache's status field.
+       the error codes should give sufficient information. If more is needed
+       the user should either check the logfile or manually run with verbose.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -84,3 +84,4 @@ v0.8.10 Fixed wrong schema error by having the plugin_settings being validated
         exceptions by adding keywords to the "supr" calls. Added exception
         message to the debug so the --debug output contains the full information.
 v0.8.11 Added 'Delimiter': '*' to S3 generic, necessary to iterate AWS buckets.
+v0.8.12 Added timeouts to S3 and DAV methods of 5 seconds.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -88,3 +88,4 @@ v0.8.12 Added timeouts to S3 and DAV methods of 5 seconds.
 v0.9.0 Added multithreading so that endpoints don't have to wait for others to
         finish. Added function to check Dynafed's connection stats from memcache
         in order to flag endpoints that are offline and skip them from checks.
+v0.9.1 Added verbose option to print on sterr logger events.

--- a/README.md
+++ b/README.md
@@ -70,8 +70,16 @@ Options:
   Output options:
     --debug             Declare to enable debug output on stdout.
     -m, --memcached     Declare to enable uploading information to memcached.
+    --json              Set to output json file with storage stats.
+    -o OUTPUT_DIR, --output_dir=OUTPUT_DIR
+                        Directory to output storage stat files. Defautl: /tmp
+    --plain             Set to output stats to plain txt file.
     --stdout            Set to output stats on stdout.
+    -v, --verbose       Show on stderr events according to loglevel down to
+                        INFO.
     --xml               Set to output xml file with StAR format.
+
+  Logging options:
     --logfile=LOGFILE   Change where to ouput logs. Default:
                         /tmp/dynafed_storagestats.log
     --loglevel=LOGLEVEL

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -14,7 +14,7 @@ Prerequisites:
 """
 from __future__ import print_function
 
-__version__ = "v0.9.0"
+__version__ = "v0.9.1"
 
 import os
 import sys

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -1051,6 +1051,7 @@ class S3StorageStats(StorageStats):
             if self.plugin_settings['s3.alternate'].lower() == 'true'\
             or self.plugin_settings['s3.alternate'].lower() == 'yes':
                 api_url = '{scheme}://{netloc}/admin/bucket?format=json'.format(scheme=self.uri['scheme'], netloc=self.uri['netloc'])
+
             else:
                 api_url = '{scheme}://{domain}/admin/{bucket}?format=json'.format(scheme=self.uri['scheme'], domain=self.uri['domain'], bucket=self.uri['bucket'])
 
@@ -1062,6 +1063,7 @@ class S3StorageStats(StorageStats):
                 self.plugin_settings['s3.region'],
                 's3',
                 )
+
             flogger.debug("[%s]Requesting storage stats with: URN: %s API Method: %s Payload: %s" % (self.id, api_url, self.plugin_settings['storagestats.api'].lower(), payload))
             try:
                 r = requests.request(
@@ -1111,7 +1113,6 @@ class S3StorageStats(StorageStats):
                     stats['usage']
 
                 except KeyError as ERR:
-
                     raise UGRStorageStatsErrorS3MissingBucketUsage(
                         status_code=r.status_code,
                         error=stats['Code'],
@@ -1663,7 +1664,6 @@ def get_endpoints(config_dir="/etc/ugr/conf.d/"):
 def create_free_space_request_content():
     """
     Creates an XML for requesting of free space on remote WebDAV server.
-
     :return: the XML string of request content.
     """
     ############# Creating loggers ################
@@ -1895,7 +1895,9 @@ def setup_logger(logfile="/tmp/dynafed_storagestats.log", loglevel="WARNING", ve
 
 def get_storagestats(endpoint):
     """
-    Create a single StAR XML file for all endpoints passed to this function.
+    Runs get_storagestats() method for the endpoint passed as argument if
+    it has not been flagged as offline. It handles exceptions to failures
+    in obtaining the statas.
     """
     ############# Creating loggers ################
     flogger = logging.getLogger(__name__)

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 """
 Module to interact with UGR's configuration files in order to obtain
 storage status information from various types of endpoints.
@@ -524,7 +524,7 @@ class StorageStats(object):
             },
             'storagestats.api': {
                 'default': 'generic',
-                'required': True,
+                'required': False,
                 'valid': ['generic'],
             },
             'ssl_check': {
@@ -957,7 +957,7 @@ class S3StorageStats(StorageStats):
             },
             'storagestats.api': {
                 'default': 'generic',
-                'required': True,
+                'required': False,
                 'valid': ['ceph-admin', 'generic'],
             },
             's3.priv_key': {

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -132,6 +132,10 @@ group.add_option('--stdout',
 #                   dest='verbose', action='count',
 #                   help='Increase verbosity level for debugging this script (on stderr)'
 #                   )
+group.add_option('-v', '--verbose',
+                 dest='verbose', action='store_true', default=False,
+                 help='Show on stderr events >= INFO loglevel.'
+                )
 group.add_option('--xml',
                  dest='output_xml', action='store_true', default=False,
                  help='Set to output xml file with StAR format.'
@@ -1844,7 +1848,7 @@ def output_plain(endpoints, output_dir="/tmp"):
             )
     output.close()
 
-def setup_logger(logfile="/tmp/dynafed_storagestats.log", loglevel="WARNING"):
+def setup_logger(logfile="/tmp/dynafed_storagestats.log", loglevel="WARNING", verbose=False):
     """
     Setup the loggers to be used throughout the script. We need at least two,
     one to log onto a logfile and a second with the TailLogger class defined
@@ -1862,8 +1866,17 @@ def setup_logger(logfile="/tmp/dynafed_storagestats.log", loglevel="WARNING"):
     # Create file handler and set level from cli or default to settings.log
     log_handler_file = logging.FileHandler(logfile, mode='a')
     log_handler_file.setFormatter(log_format_file)
-    # Add handlers
+    # Add handler
     flogger.addHandler(log_handler_file)
+
+    # Create STDERR hanler if verbose is requested.
+    if verbose:
+        log_format_stderr = logging.Formatter('%(asctime)s - [%(levelname)s]%(message)s')
+        log_handler_stderr = logging.StreamHandler()
+        log_handler_stderr.setLevel('INFO')
+        log_handler_stderr.setFormatter(log_format_stderr)
+        # Add handler
+        flogger.addHandler(log_handler_stderr)
 
     ## create memcached logger
     # Create TailLogger
@@ -1927,6 +1940,7 @@ if __name__ == '__main__':
     flogger, mlogger, memcached_logline = setup_logger(
         logfile=options.logfile,
         loglevel=options.loglevel,
+        verbose=options.verbose,
         )
 
     # Create list of StorageStats objects, one for each configured endpoint.

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -134,7 +134,7 @@ group.add_option('--stdout',
 #                   )
 group.add_option('-v', '--verbose',
                  dest='verbose', action='store_true', default=False,
-                 help='Show on stderr events according to loglevel down to INFO.'
+                 help='Show on stderr events according to loglevel.'
                 )
 group.add_option('--xml',
                  dest='output_xml', action='store_true', default=False,
@@ -1873,7 +1873,7 @@ def setup_logger(logfile="/tmp/dynafed_storagestats.log", loglevel="WARNING", ve
     if verbose:
         log_format_stderr = logging.Formatter('%(asctime)s - [%(levelname)s]%(message)s')
         log_handler_stderr = logging.StreamHandler()
-        log_handler_stderr.setLevel('INFO')
+        log_handler_stderr.setLevel(num_loglevel)
         log_handler_stderr.setFormatter(log_format_stderr)
         # Add handler
         flogger.addHandler(log_handler_stderr)

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 """
 Module to interact with UGR's configuration files in order to obtain
 storage status information from various types of endpoints.

--- a/dynafed_storagestats.py
+++ b/dynafed_storagestats.py
@@ -134,7 +134,7 @@ group.add_option('--stdout',
 #                   )
 group.add_option('-v', '--verbose',
                  dest='verbose', action='store_true', default=False,
-                 help='Show on stderr events >= INFO loglevel.'
+                 help='Show on stderr events according to loglevel down to INFO.'
                 )
 group.add_option('--xml',
                  dest='output_xml', action='store_true', default=False,


### PR DESCRIPTION
Revamped the exception handling and loggers in order to remove the "mlogger" while keeping a consistent format on error reporting and removing the necessity to instantiate a second logger. This also facilitates flexibility for exception handling so these can be removed from levels where it does not belong (before it was used for logging as well and that was a bad design.) Removed error message from memcache's status field. the error codes should give sufficient information. If more is needed the user should either check the logfile or manually run with verbose.