### PR TITLE
v1.0.11

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -186,3 +186,6 @@ v10.0.10
   ADDED: get_file method to AzureStorageShare to generate file list for reports.
   ADDED: storagestats.periodicity option validator.
   CHANGE: Moved time helper functions to time.py file.
+v1.0.11
+  BUGFIX: DAV storage now properly caluclates free space when quota is manually
+          set and RFC4331 is used to get stats.

--- a/dynafed_storagestats/xml.py
+++ b/dynafed_storagestats/xml.py
@@ -218,7 +218,8 @@ def process_rfc4331_response(response, storage_share):
 
     # Determine which value to use for the quota.
     if storage_share.plugin_settings['storagestats.quota'] == 'api':
-        storage_share.stats['quota'] = storage_share.stats['bytesused'] + storage_share.stats['bytesfree']
+        storage_share.stats['quota'] = (storage_share.stats['bytesused']
+                                        + storage_share.stats['bytesfree'])
 
         # If quota-available-bytes is reported as '0' could be
         # because no quota is provided, or the endpoint is
@@ -231,3 +232,6 @@ def process_rfc4331_response(response, storage_share):
 
     else:
         storage_share.stats['quota'] = storage_share.plugin_settings['storagestats.quota']
+        # Calculate free space using pre-set quota.
+        storage_share.stats['bytesfree'] = (storage_share.stats['quota']
+                                            - storage_share.stats['bytesused'])

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.10',
+    version='1.0.11',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
v1.0.11: DAV storage now properly caluclates free space when quota is manually set and RFC4331 is used to get stats.