### PR TITLE
v1.0.12

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -172,3 +172,5 @@ v1.0.6
 v1.0.7
   ADDED: Adds support to specify more than one endpoint to check instead of just
          one or all, using the -e flag.
+v1.0.8
+  CHANGE: Import full path to exceptions modules. Removed 'DSS' from class names.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -191,3 +191,5 @@ v1.0.11
           set and RFC4331 is used to get stats.
   ADDED: Exception handler and logging when file list report is not supported
          by plugin type using "AttributeError" exception.
+v1.0.12
+  CHANGE: Renamed 'periodicity' to 'frequency'.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -186,3 +186,6 @@ v10.0.10
   ADDED: get_file method to AzureStorageShare to generate file list for reports.
   ADDED: storagestats.periodicity option validator.
   CHANGE: Moved time helper functions to time.py file.
+v1.0.11
+  BUGFIX: DAV storage now properly caluclates free space when quota is manually
+          set and RFC4331 is used to get stats.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -168,9 +168,17 @@ v1.0.5
          This will skip the file if there are issues decoding and log a warning.
 v1.0.6
   ADDED: __init__.py files to create pypi package.
-
 v1.0.7
   ADDED: Adds support to specify more than one endpoint to check instead of just
          one or all, using the -e flag.
 v1.0.8
   CHANGE: Import full path to exceptions modules. Removed 'DSS' from class names.
+v1.0.9
+  ADDED: python-dateutil requirement.
+  ADDED: now_in_utc()
+  ADDED: mask_timestamp_by_delta()
+  ADDED: '-p', '--delta', '-o' switches to reports sub-command.
+  ADDED: S3's list-objects function to output a file list instead of storage
+         stats when the 'reports' sub-command is called.
+  CHANGE: All time module imports have been changed to datetime module.
+  CHANGE: enabled 'reports' sub-command.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -189,3 +189,5 @@ v10.0.10
 v1.0.11
   BUGFIX: DAV storage now properly caluclates free space when quota is manually
           set and RFC4331 is used to get stats.
+  ADDED: Exception handler and logging when file list report is not supported
+         by plugin type using "AttributeError" exception.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -193,3 +193,6 @@ v1.0.11
          by plugin type using "AttributeError" exception.
 v1.0.12
   CHANGE: Renamed 'periodicity' to 'frequency'.
+  CHANGE: Moved -v switch to the positional arguments, now it needs to be placed
+          after them instead of in-between.
+  ADDED: Exception handling when unable to create repot files.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -182,3 +182,7 @@ v1.0.9
          stats when the 'reports' sub-command is called.
   CHANGE: All time module imports have been changed to datetime module.
   CHANGE: enabled 'reports' sub-command.
+v10.0.10
+  ADDED: get_file method to AzureStorageShare to generate file list for reports.
+  ADDED: storagestats.periodicity option validator.
+  CHANGE: Moved time helper functions to time.py file.

--- a/README.md
+++ b/README.md
@@ -42,19 +42,15 @@ Make sure the user that runs it is able to read UGR's configuration files.
 
 ```bash
 dynafed-storage -h
-usage: dynafed-storage [-h] [-v] [--logfile LOGFILE]
-                            [--loglevel {DEBUG,INFO,WARNING,ERROR}]
-                            {stats,reports} ...
+usage: dynafed-storage [-h] {reports,stats} ...
 
 positional arguments:
-  {stats,reports}       sub-command help
-    stats               Subcommand to contact StorageEndpoints and output
-                        stats.
-    reports             Subcommand to generate reports.
+  {reports,stats}
+    reports        In development
+    stats          Obtain and output storage stats.
 
 optional arguments:
-  -h, --help            show this help message and exit
-  -v, --verbose         Show on stderr events according to loglevel.
+  -h, --help       show this help message and exit
 
 ```
 #### Sub-commands
@@ -70,7 +66,7 @@ according settings.
 First run with the following flags:
 
 ```bash
-dynafed-storage -v stats -c /etc/ugr/conf.d --stdout -m
+dynafed-storage stats -v -c /etc/ugr/conf.d --stdout -m
 ```
 
 This will printout any warnings and errors as they are encountered as well as
@@ -102,7 +98,7 @@ dynafed-storage stats -c /etc/ugr/conf.d -m -e endpoint1 endpoint2
 ```bash
 dynafed-storage stats -h
 usage: dynafed-storage stats [-h] [-c [CONFIG_PATH [CONFIG_PATH ...]]]
-                             [-e [ENDPOINT [ENDPOINT ...]]]
+                             [-e [ENDPOINT [ENDPOINT ...]]] [-v]
                              [--logfile LOGFILE]
                              [--loglevel {DEBUG,INFO,WARNING,ERROR}]
                              [--memhost MEMCACHED_IP]
@@ -120,6 +116,7 @@ optional arguments:
                         Choose endpoint(s) to check. Accepts any number of
                         arguments. If not present, all endpoints will be
                         checked.
+  -v, --verbose         Show on stderr events according to loglevel.
 
 Logging options:
   --logfile LOGFILE     Set logfile's path. Default:
@@ -155,7 +152,7 @@ Output options:
                         development!!
 ```
 ##### Reports
-**Note: Currently only works with S3 endpoints**
+**Note: Only works with Azure and S3 endpoints**
 
 This sub-command is intended to be used to obtain file reports from the storage
 endpoints. At this time, what is being developed is to be able to create
@@ -174,12 +171,12 @@ filename is the endpoint's ID name in the endpoints.conf file.
 dynafed-storage reports -c ~/lab/dynafed_storagestats/tests/local/ -o /tmp/delete --delta 1 -p rucio -e endpoint1 endpoint2
 ```
 
-**stats help:**
+**reports help:**
 ```bash
 dynafed-storage reports --help
 usage: dynafed-storage reports [-h] [-c [CONFIG_PATH [CONFIG_PATH ...]]]
-                               [-e [ENDPOINT [ENDPOINT ...]]] [--delta DELTA]
-                               [--logfile LOGFILE]
+                               [--delta DELTA] [-e [ENDPOINT [ENDPOINT ...]]]
+                               [-v] [--logfile LOGFILE]
                                [--loglevel {DEBUG,INFO,WARNING,ERROR}]
                                [-o OUTPUT_PATH] [-p PREFIX]
 
@@ -189,12 +186,13 @@ optional arguments:
                         Path to UGR's endpoint .conf files or directories.
                         Accepts any number of arguments. Default:
                         '/etc/ugr/conf.d'.
+  --delta DELTA         Mask for Last Modified Date of files. Integer in days.
+                        Default: 1
   -e [ENDPOINT [ENDPOINT ...]], --endpoint [ENDPOINT [ENDPOINT ...]]
                         Choose endpoint(s) to check. Accepts any number of
                         arguments. If not present, all endpoints will be
                         checked.
-  --delta DELTA         Mask for Last Modified Date of files. Integer in days.
-                        Default: 1
+  -v, --verbose         Show on stderr events according to loglevel.
 
 Logging options:
   --logfile LOGFILE     Set logfile's path. Default:
@@ -206,9 +204,8 @@ Output options:
   -o OUTPUT_PATH, --output-dir OUTPUT_PATH
                         Set output directory. Default: '.'
   -p PREFIX, --path PREFIX, --prefix PREFIX
-                        Set the prefix/path from where to make the
+                        Set the prefix/path from where to start the recursive
                         list.Default: ''
-
 ```
 **Important Note: DEBUG level might print an enormous amount of data as it will
 log the contents obtained from requests. In the case of the generic methods this
@@ -233,8 +230,14 @@ using the relevant API. Failing this, a default quota of 1TB will used.
 Will try to obtain the quota from the storage endpoint. If that fails a default
 of 1TB will be used.
 
-##### bytes
+##### (bytes)
 The quota can be specify in bytes, megabytes, mebibytes, etc. Lower or uppercase.
+
+```
+locplugin.<ID>.storagestats.frequency: [ 600 ]
+```
+
+This setting tells the script the number of seconds to wait before checking the endpoint again according to the timestamp of the last check stored in memcache. The default is 10 minutes (600 seconds).
 
 ### Azure
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,38 @@ it is not in the repos, run the following command:
 ```bash
 sudo  python3 /usr/lib/python3.4/site-packages/easy_install.py pip
 ```
+## Known issues
+-
 
 ## Usage
+Make sure the user that runs it is able to read UGR's configuration files.
 
-This module is intended to be run periodically as a cron job, make sure the
-user that runs it is able to read UGR's configuration files.
+```bash
+dynafed-storage -h
+usage: dynafed-storage [-h] [-v] [--logfile LOGFILE]
+                            [--loglevel {DEBUG,INFO,WARNING,ERROR}]
+                            {stats,reports} ...
 
-It has two sub commands:
--stats: Contacts each storage endpoint, obtains available stats and outputs
-them according settings.
--reports: In development, nothing at the moment but ideally will be used to
-create file lists and stats reports in formats according to experiment's needs.
+positional arguments:
+  {stats,reports}       sub-command help
+    stats               Subcommand to contact StorageEndpoints and output
+                        stats.
+    reports             Subcommand to generate reports.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --verbose         Show on stderr events according to loglevel.
+
+```
+#### Sub-commands
+##### Stats
+
+This sub-command is intended to be run periodically as a cron job in order to
+upload the stats into memcached so that Dynafed can use it to be aware of the
+storage capacity of the storage endpoints.
+
+It contacts each storage endpoint, obtains available stats and outputs them
+according settings.
 
 First run with the following flags:
 
@@ -74,28 +95,10 @@ If instead of checking all configured endpoints, specific endpoint ID's can be
 specified with the "-e" flag:
 
 ```bash
-dynafed-storage stats -c /etc/ugr/conf.d -m -e endpoint1 endpoint2 
+dynafed-storage stats -c /etc/ugr/conf.d -m -e endpoint1 endpoint2
 ```
 
-To get help:
-```bash
-dynafed-storage -h
-usage: dynafed-storage [-h] [-v] [--logfile LOGFILE]
-                            [--loglevel {DEBUG,INFO,WARNING,ERROR}]
-                            {stats,reports} ...
-
-positional arguments:
-  {stats,reports}       sub-command help
-    stats               Subcommand to contact StorageEndpoints and output
-                        stats.
-    reports             Subcommand to generate reports.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --verbose         Show on stderr events according to loglevel.
-
-```
-
+**stats help:**
 ```bash
 dynafed-storage stats -h
 usage: dynafed-storage stats [-h] [-c [CONFIG_PATH [CONFIG_PATH ...]]]
@@ -151,6 +154,62 @@ Output options:
                         filename.Default: dynafed_storagestats.json!!In
                         development!!
 ```
+##### Reports
+**Note: Currently only works with S3 endpoints**
+
+This sub-command is intended to be used to obtain file reports from the storage
+endpoints. At this time, what is being developed is to be able to create
+file dumps with the intention of using the for Rucio's integrity checks for
+cloud based storage such as S3 and Azure since other grid storage solutions like
+dCache and DPM have their own tools.
+
+For more information on this file dumps: [DDMDarkDataAndLostFiles](https://twiki.cern.ch/twiki/bin/view/AtlasComputing/DDMDarkDataAndLostFiles)
+
+Usage example:
+This will create a file at /tmp/ containing a list of files under the 'rucio'
+prefix that are a day older from endpoints 'entpoint1' and 'endpoint2'. The
+filename is the endpoint's ID name in the endpoints.conf file.
+
+```bash
+dynafed-storage reports -c ~/lab/dynafed_storagestats/tests/local/ -o /tmp/delete --delta 1 -p rucio -e endpoint1 endpoint2
+```
+
+**stats help:**
+```bash
+dynafed-storage reports --help
+usage: dynafed-storage reports [-h] [-c [CONFIG_PATH [CONFIG_PATH ...]]]
+                               [-e [ENDPOINT [ENDPOINT ...]]] [--delta DELTA]
+                               [--logfile LOGFILE]
+                               [--loglevel {DEBUG,INFO,WARNING,ERROR}]
+                               [-o OUTPUT_PATH] [-p PREFIX]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c [CONFIG_PATH [CONFIG_PATH ...]], --config [CONFIG_PATH [CONFIG_PATH ...]]
+                        Path to UGR's endpoint .conf files or directories.
+                        Accepts any number of arguments. Default:
+                        '/etc/ugr/conf.d'.
+  -e [ENDPOINT [ENDPOINT ...]], --endpoint [ENDPOINT [ENDPOINT ...]]
+                        Choose endpoint(s) to check. Accepts any number of
+                        arguments. If not present, all endpoints will be
+                        checked.
+  --delta DELTA         Mask for Last Modified Date of files. Integer in days.
+                        Default: 1
+
+Logging options:
+  --logfile LOGFILE     Set logfile's path. Default:
+                        /tmp/dynafed_storagestats.log
+  --loglevel {DEBUG,INFO,WARNING,ERROR}
+                        Set log output level. Default: WARNING.
+
+Output options:
+  -o OUTPUT_PATH, --output-dir OUTPUT_PATH
+                        Set output directory. Default: '.'
+  -p PREFIX, --path PREFIX, --prefix PREFIX
+                        Set the prefix/path from where to make the
+                        list.Default: ''
+
+```
 **Important Note: DEBUG level might print an enormous amount of data as it will
 log the contents obtained from requests. In the case of the generic methods this
 will print all the stats for each file being parsed. It is recommended to use
@@ -160,10 +219,6 @@ this level with only the endpoint one wants to troubleshoot.**
 
 In order to use the correct methods for each storage type some settings should
 be added to the endpoints.conf configuration file.
-
-### Known issues
-
-:)
 
 ### General
 

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -96,6 +96,16 @@ def add_reports_subparser(subparser):
              "If not present, all endpoints will be checked."
     )
 
+    parser.add_argument(
+        '--delta',
+        action='store',
+        default=1,
+        dest='delta',
+        type=int,
+        help="Mask for Last Modified Date of files. Integer in days. " \
+             "Default: 1"
+    )
+
     # Logging options
     group_logging = parser.add_argument_group("Logging options")
     group_logging.add_argument(
@@ -118,47 +128,38 @@ def add_reports_subparser(subparser):
 
     # Output Options
     group_output = parser.add_argument_group("Output options")
-    group_output.add_argument(
-        '--debug',
-        action='store_true',
-        default=False,
-        dest='debug',
-        help="Declare to enable debug output on stdout."
-    )
+    # group_output.add_argument(
+    #     '--debug',
+    #     action='store_true',
+    #     default=False,
+    #     dest='debug',
+    #     help="Declare to enable debug output on stdout."
+    # )
 
-    group_output.add_argument(
-        '-f', '--filename',
-        action='store',
-        default='report.txt',
-        dest='report_filename',
-        help="Set output filename. " \
-             "Default: 'report_filename'"
-    )
+    # group_output.add_argument(
+    #     '-f', '--filename',
+    #     action='store',
+    #     default='report.txt',
+    #     dest='report_filename',
+    #     help="Set output filename. " \
+    #          "Default: 'report_filename'"
+    # )
 
     group_output.add_argument(
         '-o', '--output-dir',
         action='store',
         default='.',
         dest='output_path',
-        help="Set output directory for flags -j, -x and -p. " \
+        help="Set output directory. " \
              "Default: '.'"
     )
     group_output.add_argument(
-        '-p', '--plain',
+        '-p', '--path', '--prefix',
         action='store',
-        const="dynafed_storagestats.txt",
-        default=False,
-        dest='to_plaintext',
-        nargs='?',
-        help="Set to output stats to plain txt file. Add argument to set filename." \
-             "Default: dynafed_storagestats.txt"
-    )
-    group_output.add_argument(
-        '--stdout',
-        action='store_true',
-        default=False,
-        dest='output_stdout',
-        help="Set to output stats on stdout."
+        default='',
+        dest='prefix',
+        help="Set the prefix/path from where to make the list." \
+             "Default: ''"
     )
 
 

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -158,7 +158,7 @@ def add_reports_subparser(subparser):
         action='store',
         default='',
         dest='prefix',
-        help="Set the prefix/path from where to make the list." \
+        help="Set the prefix/path from where to start the recursive list." \
              "Default: ''"
     )
 

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -48,14 +48,6 @@ def add_general_options(parser):
     parser -- Object form argparse.ArgumentParser()
 
     """
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        default=False,
-        dest='verbose',
-        help="Show on stderr events according to loglevel."
-    )
-
 
 def add_reports_subparser(subparser):
     """Add optional arguments for the 'reports' sub-command.
@@ -86,6 +78,15 @@ def add_reports_subparser(subparser):
              "Default: '/etc/ugr/conf.d'."
     )
     parser.add_argument(
+        '--delta',
+        action='store',
+        default=1,
+        dest='delta',
+        type=int,
+        help="Mask for Last Modified Date of files. Integer in days. " \
+             "Default: 1"
+    )
+    parser.add_argument(
         '-e', '--endpoint',
         action='store',
         default=['all'],
@@ -95,15 +96,12 @@ def add_reports_subparser(subparser):
              "Accepts any number of arguments. "
              "If not present, all endpoints will be checked."
     )
-
     parser.add_argument(
-        '--delta',
-        action='store',
-        default=1,
-        dest='delta',
-        type=int,
-        help="Mask for Last Modified Date of files. Integer in days. " \
-             "Default: 1"
+        '-v', '--verbose',
+        action='store_true',
+        default=False,
+        dest='verbose',
+        help="Show on stderr events according to loglevel."
     )
 
     # Logging options
@@ -199,6 +197,13 @@ def add_stats_subparser(subparser):
         help="Choose endpoint(s) to check. " \
              "Accepts any number of arguments. "
              "If not present, all endpoints will be checked."
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        default=False,
+        dest='verbose',
+        help="Show on stderr events according to loglevel."
     )
 
     # Logging options

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -71,6 +71,9 @@ def add_reports_subparser(subparser):
     )
 
     # Set the sub-command routine to run.
+    parser.set_defaults(cmd='reports')
+
+    # Set the sub-command routine to run.
     # General options
     parser.add_argument(
         '-c', '--config',

--- a/dynafed_storagestats/azure/base.py
+++ b/dynafed_storagestats/azure/base.py
@@ -55,3 +55,19 @@ class AzureStorageShare(dynafed_storagestats.base.StorageShare):
         if self.plugin_settings['storagestats.api'].lower() == 'generic' \
         or self.plugin_settings['storagestats.api'].lower() == 'list-blobs':
             azurehelpers.list_blobs(self)
+
+
+    def get_filelist(self, delta=1, prefix='', report_file='/tmp/filelist_report.txt'):
+        """Contact endpoint and generate a file-list.
+
+        Generates a list using the prefix var to select specific keys.
+
+        """
+
+        azurehelpers.list_blobs(
+            self,
+            delta,
+            prefix,
+            report_file=report_file,
+            request='filelist'
+        )

--- a/dynafed_storagestats/azure/helpers.py
+++ b/dynafed_storagestats/azure/helpers.py
@@ -6,12 +6,17 @@ from azure.storage.blob.baseblobservice import BaseBlobService
 import azure.common
 
 import dynafed_storagestats.exceptions
+import dynafed_storagestats.helpers
+import dynafed_storagestats.time
 
 ###############
 ## Functions ##
 ###############
 
-def list_blobs(storage_share):
+def list_blobs(storage_share, delta=1, prefix='',
+               report_file='/tmp/filelist_report.txt',
+               request='storagestats'
+               ):
     """Contact Azure endpoint using "list_blobs" method.
 
     Contacts an Azure blob and uses the "list_blobs" API to recursively obtain
@@ -31,7 +36,9 @@ def list_blobs(storage_share):
 
     _base_blob_service = BaseBlobService(
         account_name=storage_share.uri['account'],
-        account_key=storage_share.plugin_settings['azure.key']
+        account_key=storage_share.plugin_settings['azure.key'],
+        # Set to true if using Azurite storage emulator for testing.
+        is_emulated=False
     )
 
     _container_name = storage_share.uri['container']
@@ -52,6 +59,7 @@ def list_blobs(storage_share):
                 _container_name,
                 marker=_next_marker,
                 timeout=_timeout,
+                prefix=prefix,
             )
 
         except azure.common.AzureMissingResourceHttpError as ERR:
@@ -78,24 +86,39 @@ def list_blobs(storage_share):
             )
 
         else:
-            try:
-                _blobs.items
-            except AttributeError:
-                storage_share.stats['bytesused'] = 0
-                break
-            else:
-                _next_marker = _blobs.next_marker
-
-                try:
-                    for _blob in _blobs:
-                        _total_bytes += _blob.properties.content_length
-                        _total_files += 1
-
-                except azure.common.AzureHttpError:
-                    pass
-
-                if not _next_marker:
+            # Check what type of request is asked being used.
+            if request == 'storagestats':
+                try: # Make sure we got a list of objects.
+                    _blobs.items
+                except AttributeError:
+                    storage_share.stats['bytesused'] = 0
                     break
+                else:
+                    try:
+                        for _blob in _blobs:
+                            _total_bytes += _blob.properties.content_length
+                            _total_files += 1
+                    # Investigate
+                    except azure.common.AzureHttpError:
+                        pass
+
+            elif request == 'filelist':
+                try: # Make sure we got a list of objects.
+                    _blobs.items
+                except AttributeError:
+                    break
+                else:
+                    for _blob in _blobs:
+                        # Output files older than the specified delta.
+                        if dynafed_storagestats.time.mask_timestamp_by_delta(_blob.properties.last_modified, delta):
+                            report_file.write("%s\n" % _blob.name)
+                            _total_files += 1
+
+            # Exit if no "NextMarker" as list is now over.
+            if _next_marker:
+                _next_marker = _blobs.next_marker
+            else:
+                break
 
     storage_share.stats['bytesused'] = _total_bytes
     storage_share.stats['quota'] = storage_share.plugin_settings['storagestats.quota']

--- a/dynafed_storagestats/azure/helpers.py
+++ b/dynafed_storagestats/azure/helpers.py
@@ -5,7 +5,7 @@ import logging
 from azure.storage.blob.baseblobservice import BaseBlobService
 import azure.common
 
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 ###############
 ## Functions ##
@@ -55,7 +55,7 @@ def list_blobs(storage_share):
             )
 
         except azure.common.AzureMissingResourceHttpError as ERR:
-            raise exceptions.DSSErrorAzureContainerNotFound(
+            raise dynafed_storagestats.exceptions.ErrorAzureContainerNotFound(
                 error='ContainerNotFound',
                 status_code="404",
                 debug=str(ERR),
@@ -63,7 +63,7 @@ def list_blobs(storage_share):
             )
 
         except azure.common.AzureHttpError as ERR:
-            raise exceptions.DSSConnectionErrorAzureAPI(
+            raise dynafed_storagestats.exceptions.ConnectionErrorAzureAPI(
                 error='ConnectionError',
                 status_code="400",
                 debug=str(ERR),
@@ -71,7 +71,7 @@ def list_blobs(storage_share):
             )
 
         except azure.common.AzureException as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error='ConnectionError',
                 status_code="400",
                 debug=str(ERR),

--- a/dynafed_storagestats/base.py
+++ b/dynafed_storagestats/base.py
@@ -122,7 +122,7 @@ class StorageShare():
                 'valid': ['generic'],
             },
             'storagestats.frequency': {
-                'default': '3600',
+                'default': '600',
                 'required': False,
                 'status_code': '072'
             },

--- a/dynafed_storagestats/base.py
+++ b/dynafed_storagestats/base.py
@@ -6,7 +6,7 @@ import time
 from urllib.parse import urlsplit
 
 import dynafed_storagestats.helpers
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 #############
 ## Classes ##
@@ -174,21 +174,21 @@ class StorageShare():
             except KeyError:
                 try:
                     if self.validators[_setting]['required']:
-                        raise exceptions.DSSConfigFileErrorMissingRequiredSetting(
+                        raise dynafed_storagestats.exceptions.ConfigFileErrorMissingRequiredSetting(
                             error="MissingRequiredSetting",
                             setting=_setting,
                             status_code=self.validators[_setting]['status_code'],
                         )
 
                     else:
-                        raise exceptions.DSSConfigFileWarningMissingSetting(
+                        raise dynafed_storagestats.exceptions.ConfigFileWarningMissingSetting(
                             error="MissingSetting",
                             setting=_setting,
                             setting_default=self.validators[_setting]['default'],
                             status_code=self.validators[_setting]['status_code'],
                         )
 
-                except exceptions.DSSConfigFileErrorMissingRequiredSetting as ERR:
+                except dynafed_storagestats.exceptions.ConfigFileErrorMissingRequiredSetting as ERR:
                     # Mark StorageShare/endpoint to be skipped with a reason.
                     self.stats['check'] = 'MissingRequiredSetting'
                     self.plugin_settings.update({_setting: ''})
@@ -197,7 +197,7 @@ class StorageShare():
                     self.debug.append("[ERROR]" + ERR.debug)
                     self.status.append("[ERROR]" + ERR.error_code)
 
-                except exceptions.DSSConfigFileWarningMissingSetting as WARN:
+                except dynafed_storagestats.exceptions.ConfigFileWarningMissingSetting as WARN:
                     # Set the default value for this setting.
                     self.plugin_settings.update({_setting: self.validators[_setting]['default']})
 
@@ -213,7 +213,7 @@ class StorageShare():
                     if self.plugin_settings[_setting] not in self.validators[_setting]['valid']:
                         # Mark StorageShare/endpoint to be skipped with a reason.
                         self.stats['check'] = 'InvalidSetting'
-                        raise exceptions.DSSConfigFileErrorInvalidSetting(
+                        raise dynafed_storagestats.exceptions.ConfigFileErrorInvalidSetting(
                             error="InvalidSetting",
                             setting=_setting,
                             status_code=self.validators[_setting]['status_code'],

--- a/dynafed_storagestats/base.py
+++ b/dynafed_storagestats/base.py
@@ -121,6 +121,11 @@ class StorageShare():
                 'status_code': '070',
                 'valid': ['generic'],
             },
+            'storagestats.periodicity': {
+                'default': '3600',
+                'required': False,
+                'status_code': '072'
+            },
             'storagestats.quota': {
                 'default': 'api',
                 'required': False,

--- a/dynafed_storagestats/base.py
+++ b/dynafed_storagestats/base.py
@@ -1,7 +1,7 @@
 """Define the base Classes StorageEndpoint and StorageShares."""
 
+import datetime
 import logging
-import time
 
 from urllib.parse import urlsplit
 
@@ -103,7 +103,7 @@ class StorageShare():
             'endtime': 0,
             'filecount': -1,
             'quota': 1000**4,
-            'starttime': int(time.time()),
+            'starttime': int(datetime.datetime.now().timestamp()),
             'check': True, # To flag whether this endpoint should be contacted.
         }
 

--- a/dynafed_storagestats/base.py
+++ b/dynafed_storagestats/base.py
@@ -121,7 +121,7 @@ class StorageShare():
                 'status_code': '070',
                 'valid': ['generic'],
             },
-            'storagestats.periodicity': {
+            'storagestats.frequency': {
                 'default': '3600',
                 'required': False,
                 'status_code': '072'

--- a/dynafed_storagestats/configloader.py
+++ b/dynafed_storagestats/configloader.py
@@ -9,7 +9,7 @@ from dynafed_storagestats.azure import base as azure
 from dynafed_storagestats.base import StorageShare, StorageEndpoint
 from dynafed_storagestats.dav import base as dav
 from dynafed_storagestats.s3 import base as s3
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 #############
 # Functions #
@@ -38,7 +38,7 @@ def factory(plugin):
         return _plugin_dict.get(plugin)
 
     else:
-        raise exceptions.DSSUnsupportedPluginError(
+        raise dynafed_storagestats.exceptions.UnsupportedPluginError(
             error="UnsupportedPlugin",
             plugin=plugin,
         )
@@ -90,7 +90,7 @@ def get_conf_files(config_path):
             )
 
     if not _config_files:
-        raise exceptions.DSSConfigFileErrorNoConfigFilesFound(
+        raise dynafed_storagestats.exceptions.ConfigFileErrorNoConfigFilesFound(
             config_path=config_path,
         )
 
@@ -174,7 +174,7 @@ def get_storage_shares(config_path):
     try:
         _config_files = get_conf_files(config_path)
 
-    except exceptions.DSSConfigFileErrorNoConfigFilesFound as ERR:
+    except dynafed_storagestats.exceptions.ConfigFileErrorNoConfigFilesFound as ERR:
         _logger.critical("%s", ERR.debug)
         print("[CRITICAL]%s" % (ERR.debug))
         sys.exit(1)
@@ -183,7 +183,7 @@ def get_storage_shares(config_path):
     try:
         _storage_shares = parse_conf_files(_config_files)
 
-    except exceptions.DSSConfigFileErrorIDMismatch as ERR:
+    except dynafed_storagestats.exceptions.ConfigFileErrorIDMismatch as ERR:
         _logger.critical("[%s]%s", ERR.storage_share, ERR.debug)
         print("[CRITICAL][%s]%s" % (ERR.storage_share, ERR.debug))
         sys.exit(1)
@@ -228,7 +228,7 @@ def get_storage_share_objects(storage_shares):
                 storage_shares[_storage_share]['plugin']
             )
 
-        except exceptions.DSSUnsupportedPluginError as ERR:
+        except dynafed_storagestats.exceptions.UnsupportedPluginError as ERR:
             _logger.error("[%s]%s", storage_shares[_storage_share]['id'], ERR.debug)
             _storage_share_object = StorageShare(storage_shares[_storage_share])
             _storage_share_object.debug.append("[ERROR]" + ERR.debug)
@@ -323,7 +323,7 @@ def parse_conf_files(config_files):
                                 )
 
                             else:
-                                raise exceptions.DSSConfigFileErrorIDMismatch(
+                                raise dynafed_storagestats.exceptions.ConfigFileErrorIDMismatch(
                                     storage_share=_id,
                                     error="SettingIDMismatch",
                                     line_number=_line_number,

--- a/dynafed_storagestats/dav/helpers.py
+++ b/dynafed_storagestats/dav/helpers.py
@@ -6,7 +6,7 @@ import time
 import requests
 
 from dynafed_storagestats import xml
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 ###############
 ## Functions ##
@@ -59,7 +59,7 @@ def list_files(storage_share):
         )
 
     except requests.exceptions.InvalidSchema as ERR:
-        raise exceptions.DSSConnectionErrorInvalidSchema(
+        raise dynafed_storagestats.exceptions.ConnectionErrorInvalidSchema(
             error='InvalidSchema',
             schema=storage_share.uri['scheme'],
             debug=str(ERR),
@@ -78,14 +78,14 @@ def list_files(storage_share):
             )
 
         except requests.exceptions.SSLError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="092",
                 debug=str(ERR),
             )
 
     except requests.ConnectionError as ERR:
-        raise exceptions.DSSConnectionError(
+        raise dynafed_storagestats.exceptions.ConnectionError(
             error=ERR.__class__.__name__,
             status_code="400",
             debug=str(ERR),
@@ -95,7 +95,7 @@ def list_files(storage_share):
         #We do some regex magic to get the file path
         _certfile = str(ERR).split(":")[-1]
         _certfile = _certfile.replace(' ', '')
-        raise exceptions.DSSConnectionErrorDAVCertPath(
+        raise dynafed_storagestats.exceptions.ConnectionErrorDAVCertPath(
             certfile=_certfile,
             debug=str(ERR),
         )
@@ -111,7 +111,7 @@ def list_files(storage_share):
                 storage_share.stats['bytesfree'] = storage_share.stats['quota'] - storage_share.stats['bytesused']
 
             else:
-                raise exceptions.DSSConnectionError(
+                raise dynafed_storagestats.exceptions.ConnectionError(
                     error='ConnectionError',
                     status_code=_response.status_code,
                     debug=_response.text,
@@ -165,7 +165,7 @@ def rfc4331(storage_share):
         )
 
     except requests.exceptions.InvalidSchema as ERR:
-        raise exceptions.DSSConnectionErrorInvalidSchema(
+        raise dynafed_storagestats.exceptions.ConnectionErrorInvalidSchema(
             error='InvalidSchema',
             schema=storage_share.uri['scheme'],
             debug=str(ERR),
@@ -184,14 +184,14 @@ def rfc4331(storage_share):
             )
 
         except requests.exceptions.SSLError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="092",
                 debug=str(ERR),
             )
 
     except requests.ConnectionError as ERR:
-        raise exceptions.DSSConnectionError(
+        raise dynafed_storagestats.exceptions.ConnectionError(
             error=ERR.__class__.__name__,
             status_code="400",
             debug=str(ERR),
@@ -201,7 +201,7 @@ def rfc4331(storage_share):
         #We do some regex magic to get the filepath
         _certfile = str(ERR).split(":")[-1]
         _certfile = _certfile.replace(' ', '')
-        raise exceptions.DSSConnectionErrorDAVCertPath(
+        raise dynafed_storagestats.exceptions.ConnectionErrorDAVCertPath(
             certfile=_certfile,
             debug=str(ERR),
         )
@@ -213,7 +213,7 @@ def rfc4331(storage_share):
                 xml.process_rfc4331_response(_response, storage_share)
 
             else:
-                raise exceptions.DSSConnectionError(
+                raise dynafed_storagestats.exceptions.ConnectionError(
                     error='ConnectionError',
                     status_code=_response.status_code,
                     debug=_response.text,

--- a/dynafed_storagestats/dav/helpers.py
+++ b/dynafed_storagestats/dav/helpers.py
@@ -1,7 +1,7 @@
 """Helper functions used to contact DAV based API's."""
 
+import datetime
 import logging
-import time
 
 import requests
 
@@ -251,7 +251,7 @@ def send_dav_request(storage_share, api_url, headers, data):
         timeout=int(storage_share.plugin_settings['conn_timeout'])
     )
     # Save time when data was obtained.
-    storage_share.stats['endtime'] = int(time.time())
+    storage_share.stats['endtime'] = int(datetime.datetime.now().timestamp())
 
     #Log contents of response
     _logger.debug(

--- a/dynafed_storagestats/exceptions.py
+++ b/dynafed_storagestats/exceptions.py
@@ -4,7 +4,7 @@
 ## Classes ##
 #############
 
-class DSSBaseException(Exception):
+class BaseException(Exception):
     """
     Base exception class for dynafed_storagestats module. Formats the message
     and debug attibutes with the variables passed from the SubClasses.
@@ -28,7 +28,7 @@ class DSSBaseException(Exception):
 
 ### Defining Error Exception Classes ###
 
-class DSSBaseError(DSSBaseException):
+class BaseError(BaseException):
     """
     Base error exception Subclass.
     """
@@ -44,7 +44,7 @@ class DSSBaseError(DSSBaseException):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileError(DSSBaseError):
+class ConfigFileError(BaseError):
     """
     Base error exception subclass for anything relating to the config file(s).
     """
@@ -60,7 +60,7 @@ class DSSConfigFileError(DSSBaseError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileErrorIDMismatch(DSSConfigFileError):
+class ConfigFileErrorIDMismatch(ConfigFileError):
     """
     Exception error when a line in the configuration file under a specific
     endpoint does not match the given endpoint ID. Usually a typo.
@@ -76,7 +76,7 @@ class DSSConfigFileErrorIDMismatch(DSSConfigFileError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileErrorInvalidSetting(DSSConfigFileError):
+class ConfigFileErrorInvalidSetting(ConfigFileError):
     """
     Exception error when the value given for an setting in the configuration file
     does not match the 'valid' values specified in the 'validators' attribute.
@@ -90,7 +90,7 @@ class DSSConfigFileErrorInvalidSetting(DSSConfigFileError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileErrorMissingRequiredSetting(DSSConfigFileError):
+class ConfigFileErrorMissingRequiredSetting(ConfigFileError):
     """
     Exception error when a setting required by this module to obtain the Storage
     Stats is missing from the config files for the endpoint being processed.
@@ -104,7 +104,7 @@ class DSSConfigFileErrorMissingRequiredSetting(DSSConfigFileError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileErrorNoConfigFilesFound(DSSConfigFileError):
+class ConfigFileErrorNoConfigFilesFound(ConfigFileError):
     """
     Exception error when no configuration files have been found.
     """
@@ -116,7 +116,7 @@ class DSSConfigFileErrorNoConfigFilesFound(DSSConfigFileError):
 
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
-class DSSMemcachedError(DSSBaseError):
+class MemcachedError(BaseError):
     """
     Base error exception subclass for issues deailng with memcached
     communication.
@@ -132,7 +132,7 @@ class DSSMemcachedError(DSSBaseError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSMemcachedConnectionError(DSSMemcachedError):
+class MemcachedConnectionError(MemcachedError):
     """
     Exception error when script cannot connect to a memcached instance as
     requested.
@@ -145,7 +145,7 @@ class DSSMemcachedConnectionError(DSSMemcachedError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSMemcachedIndexError(DSSMemcachedError):
+class MemcachedIndexError(MemcachedError):
     """
     Exception error when the requested index in memcached cannot be found.
     """
@@ -157,7 +157,7 @@ class DSSMemcachedIndexError(DSSMemcachedError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSError(DSSBaseError):
+class Error(BaseError):
     """
     Base error exception subclass for issues dealing when failing to obtain
     the endpoint's storage stats.
@@ -174,7 +174,7 @@ class DSSError(DSSBaseError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConnectionError(DSSError):
+class ConnectionError(Error):
     """
     Exception error when there is an issue connecting to the endpoint's URN.
     """
@@ -186,7 +186,7 @@ class DSSConnectionError(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConnectionErrorAzureAPI(DSSError):
+class ConnectionErrorAzureAPI(Error):
     """
     Exception error when there is an issue connecting to Azure's API.
     """
@@ -199,7 +199,7 @@ class DSSConnectionErrorAzureAPI(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConnectionErrorDAVCertPath(DSSError):
+class ConnectionErrorDAVCertPath(Error):
     """
     Exception caused when there is an issue reading a client X509 certificate
     as configured in the config files for the endpoint being processed.
@@ -213,7 +213,7 @@ class DSSConnectionErrorDAVCertPath(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConnectionErrorInvalidSchema(DSSError):
+class ConnectionErrorInvalidSchema(Error):
     """
     Exception error when the URN's schema does not match any valid options.
     """
@@ -226,7 +226,7 @@ class DSSConnectionErrorInvalidSchema(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConnectionErrorS3API(DSSError):
+class ConnectionErrorS3API(Error):
     """
     Exception error when there is an issue connecting to an S3 API.
     """
@@ -239,7 +239,7 @@ class DSSConnectionErrorS3API(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSErrorAzureContainerNotFound(DSSError):
+class ErrorAzureContainerNotFound(Error):
     """
     Exception error when the Azure container requested could not be found.
     """
@@ -252,7 +252,7 @@ class DSSErrorAzureContainerNotFound(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSErrorDAVQuotaMethod(DSSError):
+class ErrorDAVQuotaMethod(Error):
     """
     Exception error when the DAV endpoint does not support the RFC 4331 method.
     """
@@ -264,7 +264,7 @@ class DSSErrorDAVQuotaMethod(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSErrorS3MissingBucketUsage(DSSError):
+class ErrorS3MissingBucketUsage(Error):
     """
     Exception error when no bucket usage stats were returned.
     """
@@ -276,7 +276,7 @@ class DSSErrorS3MissingBucketUsage(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSOfflineEndpointError(DSSError):
+class OfflineEndpointError(Error):
     """
     Exception error when and endpoint is detected to have been flagged as offline.
     """
@@ -288,7 +288,7 @@ class DSSOfflineEndpointError(DSSError):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSUnsupportedPluginError(DSSConfigFileError):
+class UnsupportedPluginError(ConfigFileError):
     """
     Exception error when an endpoint of an unsupported type/protocol plugin
     is detected.
@@ -304,7 +304,7 @@ class DSSUnsupportedPluginError(DSSConfigFileError):
 
 ### Defining Warning Exception Classes ###
 
-class DSSBaseWarning(DSSBaseException):
+class BaseWarning(BaseException):
     """
     Base error exception Subclass.
     """
@@ -320,7 +320,7 @@ class DSSBaseWarning(DSSBaseException):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileWarning(DSSBaseWarning):
+class ConfigFileWarning(BaseWarning):
     """
     Base warning exception subclass for anything relating to the config file(s).
     """
@@ -334,7 +334,7 @@ class DSSConfigFileWarning(DSSBaseWarning):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSConfigFileWarningMissingSetting(DSSConfigFileWarning):
+class ConfigFileWarningMissingSetting(ConfigFileWarning):
     """
     Exception warning when an setting not flagged as required by this module
     to obtain the storage stats is missing from the config file(s). Prints
@@ -350,7 +350,7 @@ class DSSConfigFileWarningMissingSetting(DSSConfigFileWarning):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSWarning(DSSBaseWarning):
+class Warning(BaseWarning):
     """
     Base warning exception subclass for issues dealing when non-critical errors
     are detected when trying to obtain the endpoint's storage stats.
@@ -367,7 +367,7 @@ class DSSWarning(DSSBaseWarning):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSQuotaWarning(DSSWarning):
+class QuotaWarning(Warning):
     """
     Exception warning when no quota has been provided by the endpoint's API
     when requested. Prints out the default being used as specified in the
@@ -382,7 +382,7 @@ class DSSQuotaWarning(DSSWarning):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSCephS3QuotaDisabledWarning(DSSWarning):
+class CephS3QuotaDisabledWarning(Warning):
     """
     Exception warning when contacting a Ceph S3 Admin API and it is detected
     that no quota has been enabled for the bucket.
@@ -396,7 +396,7 @@ class DSSCephS3QuotaDisabledWarning(DSSWarning):
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
 
-class DSSDAVZeroQuotaWarning(DSSWarning):
+class DAVZeroQuotaWarning(Warning):
     """
     Exception warning when a DAV based endpoint utilizing RFC4331 returns
     quota-available-bytes as 0. It well could mean there is no more space

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -187,12 +187,29 @@ def process_storagereports(storage_endpoint, args):
     _logger = logging.getLogger(__name__)
     ###############################################
     report_file = '/tmp/filelist_report.txt'
+    prefix = ''
     try:
-        _logger.info("[%s]Contacting endpoint.", storage_endpoint.storage_shares[0].id)
+        _logger.info(
+            "[%s]Contacting endpoint.",
+            storage_endpoint.storage_shares[0].id
+        )
+
+        _logger.info(
+            "[%s]Writing file-list report to '%s'",
+            storage_endpoint.storage_shares[0].id,
+            report_file
+        )
+
+        _logger.debug(
+            "[%s]Writing file-list report using options 'report_file': '%s', 'prefix': '%s'",
+            storage_endpoint.storage_shares[0].id,
+            report_file,
+            prefix
+        )
 
         with open(report_file, 'w') as _report_file:
             storage_endpoint.storage_shares[0].get_filelist(
-                prefix='',
+                prefix=prefix,
                 report_file=_report_file,
             )
 
@@ -200,21 +217,21 @@ def process_storagereports(storage_endpoint, args):
         _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
-        print('yolo!')
+        _logger.error("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, report_file)
         os.remove(report_file)
 
     except exceptions.DSSWarning as WARN:
         _logger.warning("[%s]%s", storage_endpoint.storage_shares[0].id, WARN.debug)
         storage_endpoint.storage_shares[0].debug.append("[WARNING]" + WARN.debug)
         storage_endpoint.storage_shares[0].status.append("[WARNING]" + WARN.error_code)
-        print('yolo!')
+        _logger.warning("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, report_file)
         os.remove(report_file)
 
     except exceptions.DSSError as ERR:
         _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
-        print('yolo!')
+        _logger.error("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, report_file)
         os.remove(report_file)
 
 

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -361,6 +361,7 @@ def process_storagereports(storage_endpoint, args):
     ############# Creating loggers ################
     _logger = logging.getLogger(__name__)
     ###############################################
+
     _filepath = args.output_path + '/' + storage_endpoint.storage_shares[0].id + '.txt'
 
     try:
@@ -388,6 +389,20 @@ def process_storagereports(storage_endpoint, args):
                 prefix=args.prefix,
                 report_file=_report_file,
             )
+
+    except FileNotFoundError as ERR:
+        _logger.critical(
+            "[%s]Failed to create file. Path does not exist: %s",
+             storage_endpoint.storage_shares[0].id,
+             args.output_path
+        )
+
+    except PermissionError as ERR:
+        _logger.critical(
+            "[%s]Failed to create file. Permission denied to write at: %s",
+             storage_endpoint.storage_shares[0].id,
+             args.output_path
+        )
 
     except AttributeError as ERR:
         _logger.error(

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -214,25 +214,58 @@ def process_storagereports(storage_endpoint, args):
                 report_file=_report_file,
             )
 
+    except AttributeError as ERR:
+        _logger.error(
+            "[%s]Report creation is not supported for plugin type '%s'. " \
+            "Skipping storage endpoint.",
+            storage_endpoint.storage_shares[0].id,
+            storage_endpoint.storage_shares[0].plugin
+        )
+        _logger.error(
+            "[%s]Deleting report file '%s'",
+            storage_endpoint.storage_shares[0].id,
+            _filepath
+        )
+        os.remove(_filepath)
+
     except dynafed_storagestats.exceptions.OfflineEndpointError as ERR:
-        _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
+        _logger.error(
+            "[%s]%s",
+            storage_endpoint.storage_shares[0].id,
+            ERR.debug
+        )
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
-        _logger.error("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, _filepath)
+        _logger.error(
+            "[%s]Deleting report file '%s'",
+            storage_endpoint.storage_shares[0].id,
+            _filepath
+        )
         os.remove(_filepath)
 
     except dynafed_storagestats.exceptions.Warning as WARN:
-        _logger.warning("[%s]%s", storage_endpoint.storage_shares[0].id, WARN.debug)
+        _logger.warning(
+            "[%s]%s",
+            storage_endpoint.storage_shares[0].id,
+            WARN.debug
+        )
         storage_endpoint.storage_shares[0].debug.append("[WARNING]" + WARN.debug)
         storage_endpoint.storage_shares[0].status.append("[WARNING]" + WARN.error_code)
 
     except dynafed_storagestats.exceptions.Error as ERR:
-        _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
+        _logger.error(
+            "[%s]%s",
+            storage_endpoint.storage_shares[0].id,
+            ERR.debug
+        )
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
-        _logger.error("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, _filepath)
+        _logger.error(
+            "[%s]Deleting report file '%s'",
+            storage_endpoint.storage_shares[0].id,
+            _filepath
+        )
         os.remove(_filepath)
-
 
 
 def process_storagestats(storage_endpoint, args):
@@ -339,22 +372,39 @@ def process_endpoint_list_results(storage_share_objects):
                 storage_share_objects[0].id
             )
 
-            storage_share_objects[_storage_share].stats['filecount'] = storage_share_objects[0].stats['filecount']
-            storage_share_objects[_storage_share].stats['bytesused'] = storage_share_objects[0].stats['bytesused']
+            storage_share_objects[_storage_share].stats['filecount'] = (
+                storage_share_objects[0].stats['filecount']
+            )
+            storage_share_objects[_storage_share].stats['bytesused'] = (
+                storage_share_objects[0].stats['bytesused']
+            )
 
             # Check if the plugin settings requests the quota from API. If so,
             # copy it, else use the default or manually setup quota.
             if storage_share_objects[_storage_share].plugin_settings['storagestats.quota'] == 'api':
-                storage_share_objects[_storage_share].stats['quota'] = storage_share_objects[0].stats['quota']
-                storage_share_objects[_storage_share].stats['bytesfree'] = storage_share_objects[0].stats['bytesfree']
+                storage_share_objects[_storage_share].stats['quota'] = (
+                    storage_share_objects[0].stats['quota']
+                )
+                storage_share_objects[_storage_share].stats['bytesfree'] = (
+                    storage_share_objects[0].stats['bytesfree']
+                )
 
             else:
-                storage_share_objects[_storage_share].stats['quota'] = storage_share_objects[_storage_share].plugin_settings['storagestats.quota']
-                storage_share_objects[_storage_share].stats['bytesfree'] = storage_share_objects[_storage_share].stats['quota'] - storage_share_objects[_storage_share].stats['bytesused']
+                storage_share_objects[_storage_share].stats['quota'] = (
+                    storage_share_objects[_storage_share].plugin_settings['storagestats.quota']
+                )
+                storage_share_objects[_storage_share].stats['bytesfree'] = (
+                    storage_share_objects[_storage_share].stats['quota']
+                    - storage_share_objects[_storage_share].stats['bytesused']
+                )
 
             # Might need to append any issues with the configuration settings
-            storage_share_objects[_storage_share].status = storage_share_objects[0].status
-            storage_share_objects[_storage_share].debug = storage_share_objects[0].debug
+            storage_share_objects[_storage_share].status = (
+                storage_share_objects[0].status
+            )
+            storage_share_objects[_storage_share].debug = (
+                storage_share_objects[0].debug
+            )
 
 
 def setup_logger(logfile="/tmp/dynafed_storagestats.log", loglevel="WARNING", verbose=False):

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -1,10 +1,8 @@
 """Helper functions used by the other modules."""
 
-import datetime
 import logging, logging.handlers
 import os
 
-import dateutil.tz
 import dynafed_storagestats.exceptions
 from dynafed_storagestats import memcache
 from dynafed_storagestats import output
@@ -166,41 +164,6 @@ def get_connectionstats(storage_share_objects, memcached_ip='127.0.0.1', memcach
                     "Will be assumed 'Online'",
                     _storage_share
                 )
-
-
-def now_in_utc():
-    """Returns aware datetime object of current time in UTC
-
-
-    """
-    return datetime.datetime.now(dateutil.tz.tzutc())
-
-
-def mask_timestamp_by_delta(timestamp, delta=0):
-    """Return false for timestamps later than the masking delta in days (UTC).
-
-    Checks if the timestamp given is later than the current time +/- the
-    delta given in days. When delta == 0, it uses the current date, but when
-    delta != 0 the current date is normalized to today at 00:00 UTC before
-    calculating the mask.
-
-    Attributes:
-    timestamp -- datetime aware time object.
-    delta -- integer.
-
-    """
-
-    if delta == 0:
-        _mask = now_in_utc()
-    else:
-        _mask = now_in_utc().replace(hour=0,minute=0,second=0,microsecond=0) \
-                - datetime.timedelta(days=delta)
-
-
-    if timestamp > _mask:
-        return False
-    else:
-        return True
 
 
 def process_storagereports(storage_endpoint, args):

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -3,7 +3,7 @@
 import logging, logging.handlers
 import os
 
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 from dynafed_storagestats import memcache
 from dynafed_storagestats import output
 
@@ -88,7 +88,7 @@ def get_connectionstats(storage_share_objects, memcached_ip='127.0.0.1', memcach
         )
 
         if _idx is None:
-            raise exceptions.DSSMemcachedConnectionError()
+            raise dynafed_storagestats.exceptions.MemcachedConnectionError()
 
         if isinstance(_idx, bytes):
             _idx = str(_idx, 'utf-8')
@@ -108,9 +108,9 @@ def get_connectionstats(storage_share_objects, memcached_ip='127.0.0.1', memcach
 
         # Check if we actually got information
         if _connection_stats is None:
-            raise exceptions.DSSMemcachedIndexError()
+            raise dynafed_storagestats.exceptions.MemcachedIndexError()
 
-    except exceptions.DSSMemcachedError as ERR:
+    except dynafed_storagestats.exceptions.MemcachedError as ERR:
         _logger.error(
             "%s Server %s did not return data. All storage_shares will be " \
             "assumed 'Online'.",
@@ -213,21 +213,21 @@ def process_storagereports(storage_endpoint, args):
                 report_file=_report_file,
             )
 
-    except exceptions.DSSOfflineEndpointError as ERR:
+    except dynafed_storagestats.exceptions.OfflineEndpointError as ERR:
         _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
         _logger.error("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, report_file)
         os.remove(report_file)
 
-    except exceptions.DSSWarning as WARN:
+    except dynafed_storagestats.exceptions.Warning as WARN:
         _logger.warning("[%s]%s", storage_endpoint.storage_shares[0].id, WARN.debug)
         storage_endpoint.storage_shares[0].debug.append("[WARNING]" + WARN.debug)
         storage_endpoint.storage_shares[0].status.append("[WARNING]" + WARN.error_code)
         _logger.warning("[%s]Deleting report file '%s'", storage_endpoint.storage_shares[0].id, report_file)
         os.remove(report_file)
 
-    except exceptions.DSSError as ERR:
+    except dynafed_storagestats.exceptions.Error as ERR:
         _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
@@ -266,7 +266,7 @@ def process_storagestats(storage_endpoint, args):
                 storage_endpoint.storage_shares[0].stats['check']
             )
 
-            raise exceptions.DSSOfflineEndpointError(
+            raise dynafed_storagestats.exceptions.OfflineEndpointError(
                 status_code="400",
                 error="EndpointOffline"
             )
@@ -278,17 +278,17 @@ def process_storagestats(storage_endpoint, args):
                 storage_endpoint.storage_shares[0].stats['check']
             )
 
-    except exceptions.DSSOfflineEndpointError as ERR:
+    except dynafed_storagestats.exceptions.OfflineEndpointError as ERR:
         _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
 
-    except exceptions.DSSWarning as WARN:
+    except dynafed_storagestats.exceptions.Warning as WARN:
         _logger.warning("[%s]%s", storage_endpoint.storage_shares[0].id, WARN.debug)
         storage_endpoint.storage_shares[0].debug.append("[WARNING]" + WARN.debug)
         storage_endpoint.storage_shares[0].status.append("[WARNING]" + WARN.error_code)
 
-    except exceptions.DSSError as ERR:
+    except dynafed_storagestats.exceptions.Error as ERR:
         _logger.error("[%s]%s", storage_endpoint.storage_shares[0].id, ERR.debug)
         storage_endpoint.storage_shares[0].debug.append("[ERROR]" + ERR.debug)
         storage_endpoint.storage_shares[0].status.append("[ERROR]" + ERR.error_code)
@@ -310,7 +310,7 @@ def process_storagestats(storage_endpoint, args):
                 try:
                     output.to_memcached(storage_share, args.memcached_ip, args.memcached_port)
 
-                except exceptions.DSSMemcachedConnectionError as ERR:
+                except dynafed_storagestats.exceptions.MemcachedConnectionError as ERR:
                     _logger.error("[%s]%s", storage_share.id, ERR.debug)
                     storage_share.debug.append("[ERROR]" + ERR.debug)
                     storage_share.status = storage_share.status + "," + "[ERROR]" + ERR.error_code

--- a/dynafed_storagestats/json.py
+++ b/dynafed_storagestats/json.py
@@ -1,7 +1,8 @@
 """Functions to deal with the formatting and handling  of JSON data."""
 
+import datetime
 import json
-import time
+
 
 #############
 # Functions #
@@ -75,7 +76,7 @@ def format_wlcg(storage_endpoints, hostname="localhost"):
         # 'servicetype': "tbd",
         "implementation": "dynafed",
         # 'implementationversion': "tbd",
-        "latesupdate": int(time.time()),
+        "latesupdate": int(datetime.datetime.now().timestamp()),
         "storageservicecapacity": {
             "totalsize": _dynafed_totalsize,
             "usedsize": _dynafed_usedsize,

--- a/dynafed_storagestats/memcache.py
+++ b/dynafed_storagestats/memcache.py
@@ -2,7 +2,7 @@
 
 import memcache
 
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 #############
 # Functions #
@@ -26,7 +26,7 @@ def get(index, memcached_ip='127.0.0.1', memcached_port='11211'):
     _memcached_content = _memcached_client.get(index)
 
     if _memcached_content is None:
-        raise exceptions.DSSMemcachedIndexError()
+        raise dynafed_storagestats.exceptions.MemcachedIndexError()
 
     else:
         return _memcached_content
@@ -47,4 +47,4 @@ def set(index, data, memcached_ip='127.0.0.1', memcached_port='11211'):
     _memcached_result = _memcached_client.set(index, data)
 
     if _memcached_result == 0:
-        raise exceptions.DSSMemcachedConnectionError()
+        raise dynafed_storagestats.exceptions.MemcachedConnectionError()

--- a/dynafed_storagestats/output.py
+++ b/dynafed_storagestats/output.py
@@ -3,7 +3,7 @@
 import os
 import logging
 
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 from dynafed_storagestats import memcache
 from dynafed_storagestats import json
 from dynafed_storagestats import xml
@@ -197,7 +197,7 @@ def to_stdout(storage_endpoints, args):
                     args.memcached_port
                 )
 
-            except exceptions.DSSMemcachedIndexError as ERR:
+            except dynafed_storagestats.exceptions.MemcachedIndexError as ERR:
                 _memcached_contents = 'No content found or error connecting to memcached service.'
                 _storage_share.debug.append("[ERROR]" + ERR.debug)
 

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -49,10 +49,26 @@ def reports(ARGS):
         ARGS.config_path
     )
 
-    for _storage_share in storage_shares:
-        _storage_share.get_filelist()
+    # Create a list of StorageEndpoint objects with the StorageShares to check,
+    # based on user input or unique URL's.
+    storage_endpoints = configloader.get_storage_endpoints(
+        storage_shares,
+        ARGS.endpoint
+    )
 
+    # This tuple is necessary for the starmap function to send multiple
+    # arguments to the process_storagestats function.
+    storage_endpoints_list_and_args_tuple = [
+        (storage_endpoint, ARGS) for storage_endpoint in storage_endpoints
+    ]
 
+    # Process each storage endpoints' shares using multithreading.
+    # Number of threads to use.
+    pool = ThreadPool(len(storage_endpoints_list_and_args_tuple))
+    pool.starmap(
+        helpers.process_storagereports,
+        storage_endpoints_list_and_args_tuple
+    )
 
 
 def stats(ARGS):

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -44,7 +44,15 @@ def reports(ARGS):
     ARGS -- argparse object from dynafed_storagestats.args.parse_args()
 
     """
-    print("In development, nothing useful yet.")
+    # Get list of StorageShare objects from the configuration files.
+    storage_shares = configloader.get_storage_shares(
+        ARGS.config_path
+    )
+
+    for _storage_share in storage_shares:
+        _storage_share.get_filelist()
+
+
 
 
 def stats(ARGS):

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -89,12 +89,19 @@ def stats(ARGS):
         ARGS.config_path
     )
 
-    # Flag storage shares that have been marked offline by Dynafed.
-    helpers.get_connectionstats(
+    # Obtain current stats, if any, from memcached.
+    current_stats = helpers.get_currentstats(
         storage_shares,
         ARGS.memcached_ip,
         ARGS.memcached_port
     )
+
+    if current_stats is not None:
+        # Flag storage shares that have been marked offline by Dynafed.
+        helpers.check_connectionstats(storage_shares, current_stats)
+
+        # Flag storage shares that are under-due their period.
+        helpers.check_frequency(storage_shares, current_stats)
 
     # Create a list of StorageEndpoint objects with the StorageShares to check,
     # based on user input or unique URL's.

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -1,7 +1,6 @@
 """Defines S3's StorageShare sub-class."""
 
 import logging
-import os
 
 import dynafed_storagestats.base
 import dynafed_storagestats.s3.helpers as s3helpers
@@ -107,20 +106,12 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
         """
 
-
-        try:
-            with open(report_file, 'w') as _output:
-                s3helpers.list_objects(
-                    self,
-                    prefix,
-                    report_file=_output,
-                    request='filelist'
-                )
-        # Delete file if any error is raised. Maybe this needs to be somewhere
-        # else?
-        except:
-            print('yolo!')
-            os.remove(report_file)
+        s3helpers.list_objects(
+            self,
+            prefix,
+            report_file=report_file,
+            request='filelist'
+        )
 
 
     def validate_schema(self):

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -100,7 +100,7 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
             s3helpers.cloudwatch(self)
 
 
-    def get_filelist(self, prefix='', report_file='/tmp/filelist_report.txt'):
+    def get_filelist(self, delta=1, prefix='', report_file='/tmp/filelist_report.txt'):
         """Contact endpoint and generate a file-list.
 
         Generates a list using the prefix var to select specific keys.
@@ -109,6 +109,7 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
         s3helpers.list_objects(
             self,
+            delta,
             prefix,
             report_file=report_file,
             request='filelist'

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -81,19 +81,20 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
         ###############################################
 
-        # Getting the storage Stats CephS3's Admin API
+        # Getting the storage stats CephS3's Admin API
         if self.plugin_settings['storagestats.api'].lower() == 'ceph-admin':
             s3helpers.ceph_admin(self)
 
-        # Getting the storage Stats AWS S3 API
+        # Getting the storage stats AWS S3 API
         #elif self.plugin_settings['storagestats.api'].lower() == 'aws-cloudwatch':
 
-        # Generic list all objects and add sizes using list-objectsv2 AWS-Boto3
-        # API, should work for any compatible S3 endpoint.
+        # Getting the storage stats using AWS-Boto3 list-objects API, should
+        # work for any compatible S3 endpoint.
         elif self.plugin_settings['storagestats.api'].lower() == 'generic' \
         or   self.plugin_settings['storagestats.api'].lower() == 'list-objects':
             s3helpers.list_objects(self)
 
+        # Getting the storage stats using AWS Cloudwatch
         elif self.plugin_settings['storagestats.api'].lower() == 'cloudwatch':
             s3helpers.cloudwatch(self)
 
@@ -104,7 +105,14 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
         Generates a list using the prefix var to select specific keys.
 
         """
-        s3helpers.list_objects(self, prefix, request='filelist')
+
+        with open(report_file, 'w') as _output:
+            s3helpers.list_objects(
+                self,
+                prefix,
+                report_file=_output,
+                request='filelist'
+            )
 
 
 

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -1,6 +1,7 @@
 """Defines S3's StorageShare sub-class."""
 
 import logging
+import os
 
 import dynafed_storagestats.base
 import dynafed_storagestats.s3.helpers as s3helpers
@@ -106,12 +107,29 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
         """
 
+<<<<<<< HEAD
         s3helpers.list_objects(
             self,
             prefix,
             report_file=report_file,
             request='filelist'
         )
+=======
+
+        try:
+            with open(report_file, 'w') as _output:
+                s3helpers.list_objects(
+                    self,
+                    prefix,
+                    report_file=_output,
+                    request='filelist'
+                )
+        # Delete file if any error is raised. Maybe this needst to be somwhere
+        # else?
+        except:
+            print('yolo!')
+            os.remove(report_file)
+>>>>>>> 7ae6f457679c01b5877658479b7c84540ba8af30
 
 
     def validate_schema(self):

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -107,29 +107,12 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
         """
 
-<<<<<<< HEAD
         s3helpers.list_objects(
             self,
             prefix,
             report_file=report_file,
             request='filelist'
         )
-=======
-
-        try:
-            with open(report_file, 'w') as _output:
-                s3helpers.list_objects(
-                    self,
-                    prefix,
-                    report_file=_output,
-                    request='filelist'
-                )
-        # Delete file if any error is raised. Maybe this needst to be somwhere
-        # else?
-        except:
-            print('yolo!')
-            os.remove(report_file)
->>>>>>> 7ae6f457679c01b5877658479b7c84540ba8af30
 
 
     def validate_schema(self):

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -1,6 +1,7 @@
 """Defines S3's StorageShare sub-class."""
 
 import logging
+import os
 
 import dynafed_storagestats.base
 import dynafed_storagestats.s3.helpers as s3helpers
@@ -100,20 +101,26 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
 
     def get_filelist(self, prefix='', report_file='/tmp/filelist_report.txt'):
-        """Contanct enpoint and generate a filelist.
+        """Contact endpoint and generate a file-list.
 
         Generates a list using the prefix var to select specific keys.
 
         """
 
-        with open(report_file, 'w') as _output:
-            s3helpers.list_objects(
-                self,
-                prefix,
-                report_file=_output,
-                request='filelist'
-            )
 
+        try:
+            with open(report_file, 'w') as _output:
+                s3helpers.list_objects(
+                    self,
+                    prefix,
+                    report_file=_output,
+                    request='filelist'
+                )
+        # Delete file if any error is raised. Maybe this needs to be somewhere
+        # else?
+        except:
+            print('yolo!')
+            os.remove(report_file)
 
 
     def validate_schema(self):

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -540,7 +540,6 @@ def list_objects(storage_share, prefix='', report_file='/tmp/filelist_report.txt
                 except KeyError:
                     break
                 else:
-                    print ("chale")
                     for _file in _response['Contents']:
                         report_file.write("%s\n" % _file['Key'])
                         _total_files += 1

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -11,8 +11,9 @@ from botocore.client import Config
 import requests
 from requests_aws4auth import AWS4Auth
 
-import dynafed_storagestats.helpers
 import dynafed_storagestats.exceptions
+import dynafed_storagestats.helpers
+import dynafed_storagestats.time
 
 ###############
 ## Functions ##
@@ -375,7 +376,10 @@ def cloudwatch(storage_share):
         storage_share.stats['bytesfree'] = storage_share.stats['quota'] - storage_share.stats['bytesused']
 
 
-def list_objects(storage_share, delta=1, prefix='', report_file='/tmp/filelist_report.txt', request='storagestats'):
+def list_objects(storage_share, delta=1, prefix='',
+                 report_file='/tmp/filelist_report.txt',
+                 request='storagestats'
+                 ):
     """Contact S3 endpoint using list_objects API.
 
     Contacts an S3 endpoints and uses the "list_objects" API to recursively
@@ -545,7 +549,7 @@ def list_objects(storage_share, delta=1, prefix='', report_file='/tmp/filelist_r
                 else:
                     for _file in _response['Contents']:
                         # Output files older than the specified delta.
-                        if dynafed_storagestats.helpers.mask_timestamp_by_delta(_file['LastModified'], delta):
+                        if dynafed_storagestats.time.mask_timestamp_by_delta(_file['LastModified'], delta):
                             report_file.write("%s\n" % _file['Key'])
                             _total_files += 1
 

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -13,7 +13,7 @@ import requests
 from requests_aws4auth import AWS4Auth
 
 import dynafed_storagestats.helpers
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 ###############
 ## Functions ##
@@ -95,7 +95,7 @@ def ceph_admin(storage_share):
         )
 
     except requests.exceptions.InvalidSchema as ERR:
-        raise exceptions.DSSConnectionErrorInvalidSchema(
+        raise dynafed_storagestats.exceptions.ConnectionErrorInvalidSchema(
             error='InvalidSchema',
             schema=storage_share.uri['scheme'],
             debug=str(ERR),
@@ -126,14 +126,14 @@ def ceph_admin(storage_share):
             )
 
         except requests.exceptions.SSLError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="092",
                 debug=str(ERR),
             )
 
     except requests.ConnectionError as ERR:
-        raise exceptions.DSSConnectionError(
+        raise dynafed_storagestats.exceptions.ConnectionError(
             error=ERR.__class__.__name__,
             debug=str(ERR),
         )
@@ -147,7 +147,7 @@ def ceph_admin(storage_share):
                 _stats = _response.json()
 
             except ValueError:
-                raise exceptions.DSSConnectionErrorS3API(
+                raise dynafed_storagestats.exceptions.ConnectionErrorS3API(
                     error="NoContent",
                     status_code=_response.status_code,
                     api=storage_share.plugin_settings['storagestats.api'],
@@ -160,7 +160,7 @@ def ceph_admin(storage_share):
                 _stats['usage']
 
             except KeyError as ERR:
-                raise exceptions.DSSErrorS3MissingBucketUsage(
+                raise dynafed_storagestats.exceptions.ErrorS3MissingBucketUsage(
                     status_code=_response.status_code,
                     error=_stats['Code'],
                     debug=str(_stats)
@@ -190,14 +190,14 @@ def ceph_admin(storage_share):
                     elif _stats['bucket_quota']['enabled'] is False:
                         storage_share.stats['quota'] = dynafed_storagestats.helpers.convert_size_to_bytes("1TB")
                         storage_share.stats['bytesfree'] = storage_share.stats['quota'] - storage_share.stats['bytesused']
-                        raise exceptions.DSSCephS3QuotaDisabledWarning(
+                        raise dynafed_storagestats.exceptions.CephS3QuotaDisabledWarning(
                             default_quota=storage_share.stats['quota'],
                         )
 
                     else:
                         storage_share.stats['quota'] = dynafed_storagestats.helpers.convert_size_to_bytes("1TB")
                         storage_share.stats['bytesfree'] = storage_share.stats['quota'] - storage_share.stats['bytesused']
-                        raise exceptions.DSSQuotaWarning(
+                        raise dynafed_storagestats.exceptions.QuotaWarning(
                             error="NoQuotaGiven",
                             status_code="098",
                             default_quota=storage_share.stats['quota'],
@@ -302,35 +302,35 @@ def cloudwatch(storage_share):
             )
 
         except botoExceptions.ClientError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code=ERR.response['ResponseMetadata']['HTTPStatusCode'],
                 debug=str(ERR),
             )
 
         except botoRequestsExceptions.SSLError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="092",
                 debug=str(ERR),
             )
 
         except botoRequestsExceptions.RequestException as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="400",
                 debug=str(ERR),
             )
 
         except botoExceptions.ParamValidationError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="095",
                 debug=str(ERR),
             )
 
         except botoExceptions.BotoCoreError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="400",
                 debug=str(ERR),
@@ -361,7 +361,7 @@ def cloudwatch(storage_share):
     if storage_share.plugin_settings['storagestats.quota'] == 'api':
         storage_share.stats['quota'] = dynafed_storagestats.helpers.convert_size_to_bytes("1TB")
         storage_share.stats['bytesfree'] = storage_share.stats['quota'] - storage_share.stats['bytesused']
-        raise exceptions.DSSQuotaWarning(
+        raise dynafed_storagestats.exceptions.QuotaWarning(
             error="NoQuotaGiven",
             status_code="098",
             default_quota=storage_share.stats['quota'],
@@ -447,14 +447,14 @@ def list_objects(storage_share, prefix='', report_file='/tmp/filelist_report.txt
             _response = _connection.list_objects(**_kwargs)
 
         except botoExceptions.ClientError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code=ERR.response['ResponseMetadata']['HTTPStatusCode'],
                 debug=str(ERR),
             )
 
         except botoRequestsExceptions.InvalidSchema as ERR:
-            raise exceptions.DSSConnectionErrorInvalidSchema(
+            raise dynafed_storagestats.exceptions.ConnectionErrorInvalidSchema(
                 error='InvalidSchema',
                 schema=storage_share.uri['scheme'],
                 debug=str(ERR),
@@ -483,28 +483,28 @@ def list_objects(storage_share, prefix='', report_file='/tmp/filelist_report.txt
                 _response = _connection.list_objects(**_kwargs)
 
             except botoRequestsExceptions.SSLError as ERR:
-                raise exceptions.DSSConnectionError(
+                raise dynafed_storagestats.exceptions.ConnectionError(
                     error=ERR.__class__.__name__,
                     status_code="092",
                     debug=str(ERR),
                 )
 
         except botoRequestsExceptions.RequestException as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="400",
                 debug=str(ERR),
             )
 
         except botoExceptions.ParamValidationError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="095",
                 debug=str(ERR),
             )
 
         except botoExceptions.BotoCoreError as ERR:
-            raise exceptions.DSSConnectionError(
+            raise dynafed_storagestats.exceptions.ConnectionError(
                 error=ERR.__class__.__name__,
                 status_code="400",
                 debug=str(ERR),
@@ -558,7 +558,7 @@ def list_objects(storage_share, prefix='', report_file='/tmp/filelist_report.txt
         storage_share.stats['quota'] = dynafed_storagestats.helpers.convert_size_to_bytes("1TB")
         storage_share.stats['filecount'] = _total_files
         storage_share.stats['bytesfree'] = storage_share.stats['quota'] - storage_share.stats['bytesused']
-        raise exceptions.DSSQuotaWarning(
+        raise dynafed_storagestats.exceptions.QuotaWarning(
             error="NoQuotaGiven",
             status_code="098",
             default_quota=storage_share.stats['quota'],

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -541,10 +541,9 @@ def list_objects(storage_share, prefix='', report_file='/tmp/filelist_report.txt
                     break
                 else:
                     print ("chale")
-                    with open(report_file, 'w') as output:
-                        for _file in _response['Contents']:
-                            output.write("%s\n" % _file['Key'])
-                            _total_files += 1
+                    for _file in _response['Contents']:
+                        report_file.write("%s\n" % _file['Key'])
+                        _total_files += 1
 
                 try:
                     _kwargs['Marker'] = _response['NextMarker']

--- a/dynafed_storagestats/time.py
+++ b/dynafed_storagestats/time.py
@@ -1,0 +1,42 @@
+"""Functions to deal and handling  of time data."""
+import datetime
+import dateutil.tz
+
+#############
+# Functions #
+#############
+
+def now_in_utc():
+    """Returns aware datetime object of current time in UTC
+
+
+    """
+    
+    return datetime.datetime.now(dateutil.tz.tzutc())
+
+
+def mask_timestamp_by_delta(timestamp, delta=0):
+    """Return false for timestamps later than the masking delta in days (UTC).
+
+    Checks if the timestamp given is later than the current time +/- the
+    delta given in days. When delta == 0, it uses the current date, but when
+    delta != 0 the current date is normalized to today at 00:00 UTC before
+    calculating the mask.
+
+    Attributes:
+    timestamp -- datetime aware time object.
+    delta -- integer.
+
+    """
+
+    if delta == 0:
+        _mask = now_in_utc()
+    else:
+        _mask = now_in_utc().replace(hour=0,minute=0,second=0,microsecond=0) \
+                - datetime.timedelta(days=delta)
+
+
+    if timestamp > _mask:
+        return False
+    else:
+        return True

--- a/dynafed_storagestats/time.py
+++ b/dynafed_storagestats/time.py
@@ -6,13 +6,27 @@ import dateutil.tz
 # Functions #
 #############
 
-def now_in_utc():
-    """Returns aware datetime object of current time in UTC
+def is_later(timestamp, period):
+    """Return true if the current time > timestamp + period.
 
+    Checks if the timestamp given is later than the current time + the
+    period given in seconds.
+
+    Attributes:
+    timestamp -- integer, EPOCH.
+    period -- integer, seconds.
 
     """
-    
-    return datetime.datetime.now(dateutil.tz.tzutc())
+
+    _timestamp_to_check = (
+        datetime.datetime.fromtimestamp(timestamp, dateutil.tz.tzutc())
+        + datetime.timedelta(seconds=period)
+    )
+
+    if now_in_utc() > _timestamp_to_check:
+        return True
+    else:
+        return False
 
 
 def mask_timestamp_by_delta(timestamp, delta=0):
@@ -40,3 +54,12 @@ def mask_timestamp_by_delta(timestamp, delta=0):
         return False
     else:
         return True
+
+
+def now_in_utc():
+    """Returns aware datetime object of current time in UTC
+
+
+    """
+
+    return datetime.datetime.now(dateutil.tz.tzutc())

--- a/dynafed_storagestats/xml.py
+++ b/dynafed_storagestats/xml.py
@@ -218,7 +218,8 @@ def process_rfc4331_response(response, storage_share):
 
     # Determine which value to use for the quota.
     if storage_share.plugin_settings['storagestats.quota'] == 'api':
-        storage_share.stats['quota'] = storage_share.stats['bytesused'] + storage_share.stats['bytesfree']
+        storage_share.stats['quota'] = (storage_share.stats['bytesused']
+                                        + storage_share.stats['bytesfree'])
 
         # If quota-available-bytes is reported as '0' could be
         # because no quota is provided, or the endpoint is
@@ -231,3 +232,6 @@ def process_rfc4331_response(response, storage_share):
 
     else:
         storage_share.stats['quota'] = storage_share.plugin_settings['storagestats.quota']
+        # Calculate free space using pre-set quota.
+        storage_share.stats['bytesfree'] = (storage_share.stats['quota']
+                                            - storage_share.stats['bytesused'])

--- a/dynafed_storagestats/xml.py
+++ b/dynafed_storagestats/xml.py
@@ -7,7 +7,7 @@ import uuid
 from io import BytesIO
 from lxml import etree
 
-from dynafed_storagestats import exceptions
+import dynafed_storagestats.exceptions
 
 #############
 # Functions #
@@ -207,7 +207,7 @@ def process_rfc4331_response(response, storage_share):
     # Check that we got the requested information. If not, then
     # the method is not supported.
     if _node is None:
-        raise exceptions.DSSErrorDAVQuotaMethod(
+        raise dynafed_storagestats.exceptions.ErrorDAVQuotaMethod(
             error="UnsupportedMethod"
         )
 
@@ -224,7 +224,7 @@ def process_rfc4331_response(response, storage_share):
         # actually full. We warn for the operator to make a
         # decision.
         if storage_share.stats['bytesfree'] is 0:
-            raise exceptions.DSSDAVZeroQuotaWarning(
+            raise dynafed_storagestats.exceptions.DAVZeroQuotaWarning(
                 debug=str(response.content)
             )
 

--- a/dynafed_storagestats/xml.py
+++ b/dynafed_storagestats/xml.py
@@ -1,7 +1,8 @@
 """Functions to deal with the formatting and handling  of XML data."""
 
+import datetime
 import copy
-import time
+
 import uuid
 
 from io import BytesIO
@@ -95,7 +96,7 @@ def format_StAR(storage_endpoints):
             # update XML
             rec = etree.SubElement(xmlroot, SR+'StorageUsageRecord')
             rid = etree.SubElement(rec, SR+'RecordIdentity')
-            rid.set(SR+"createTime", time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time())))
+            rid.set(SR+"createTime", time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(datetime.datetime.now().timestamp())))
 
             # StAR StorageShare field (Optional)
             if share.star_fields['storage_share']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 azure-storage>=0.36.0
 boto3>=1.6.1
+python-dateutil>=2.7.5
 lxml>=4.2.1
 python-memcached>=1.59
 requests>=2.12.5

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.11',
+    version='1.0.12',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.8',
+    version='1.0.9',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.7',
+    version='1.0.8',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.9',
+    version='1.0.10',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.10',
+    version='1.0.11',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
v1.0.8
  CHANGE: Import full path to exceptions modules. Removed 'DSS' from class names.
v1.0.9
  ADDED: python-dateutil requirement.
  ADDED: now_in_utc()
  ADDED: mask_timestamp_by_delta()
  ADDED: '-p', '--delta', '-o' switches to reports sub-command.
  ADDED: S3's list-objects function to output a file list instead of storage
         stats when the 'reports' sub-command is called.
  CHANGE: All time module imports have been changed to datetime module.
  CHANGE: enabled 'reports' sub-command.
v10.0.10
  ADDED: get_file method to AzureStorageShare to generate file list for reports.
  ADDED: storagestats.periodicity option validator.
  CHANGE: Moved time helper functions to time.py file.
v1.0.11
  BUGFIX: DAV storage now properly caluclates free space when quota is manually
          set and RFC4331 is used to get stats.
  ADDED: Exception handler and logging when file list report is not supported
         by plugin type using "AttributeError" exception.
v1.0.12
  CHANGE: Renamed 'periodicity' to 'frequency'.
  CHANGE: Moved -v switch to the positional arguments, now it needs to be placed
          after them instead of in-between.
  ADDED: Exception handling when unable to create repot files.