### PR TITLE
v1.0.19

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -221,3 +221,7 @@ v1.0.18
   REMOVED: validate_checksum and deps, does note belong here.
 v1.0.19
   ADDED: '-f, --force' flag to checksums put to force checksum metadata update.
+  FIXED: Issue when requesting storagestats with the list-objects API only 1000
+         objects would be returned for S3 and Azure classes.
+  FIXED: Typo on memcahced missing index log line.
+  REMOVED: Redundant memcahce empty checks.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -219,3 +219,5 @@ v1.0.18
   ADDED: self contained put_object_checksum method for S3StorageShare.
   CHANGE: Renamed set_object_metadata to put_object_metadata.
   REMOVED: validate_checksum and deps, does note belong here.
+v1.0.19
+  ADDED: '-f, --force' flag to checksums put to force checksum metadata update.

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -202,6 +202,14 @@ def add_checkusms_put_subparser(subparser):
              "Required."
     )
     parser.add_argument(
+        '-f', '--force',
+        action='store_true',
+        default=False,
+        dest='force',
+        help="Force checksum to be put. " \
+             "Default: 'False'."
+    )
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true',
         default=False,

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -539,7 +539,7 @@ def process_checksums_get(storage_share, hash_type, url):
         return _checksum
 
 
-def process_checksums_put(storage_share, checksum, hash_type, url):
+def process_checksums_put(storage_share, checksum, hash_type, url, force=False):
     """Run StorageShare put_object_checksum() methods to put checksum for file/object.
 
     Run StorageShare put_object_checksum() method to put checksum on file/object,
@@ -551,6 +551,7 @@ def process_checksums_put(storage_share, checksum, hash_type, url):
     Arguments:
     storage_share -- dynafed_storagestats StorageShare object.
     checksum -- string containing checksum to put.
+    force -- boolean
     hash_type -- string that indicates the type of has requested.
     url -- string containing url to the desired file/object.
 
@@ -561,7 +562,7 @@ def process_checksums_put(storage_share, checksum, hash_type, url):
 
     try:
 
-        storage_share.put_object_checksum(checksum, hash_type, url)
+        storage_share.put_object_checksum(checksum, hash_type, url, force=force)
 
     except AttributeError as ERR:
         _logger.error(

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -300,9 +300,6 @@ def get_cached_connection_stats(return_as='string', memcached_ip='127.0.0.1', me
         memcached_port
     )
 
-    if _idx is None:
-        raise dynafed_storagestats.exceptions.MemcachedConnectionError()
-
     if isinstance(_idx, bytes):
         _idx = str(_idx, 'utf-8')
 
@@ -318,10 +315,6 @@ def get_cached_connection_stats(return_as='string', memcached_ip='127.0.0.1', me
         memcached_ip,
         memcached_port
     )
-
-    # Check if we actually got information
-    if _connection_stats is None:
-        raise dynafed_storagestats.exceptions.MemcachedIndexError()
 
     # Typecast to str if needed. Different versions of memcache module return
     # bytes.
@@ -437,10 +430,6 @@ def get_cached_storage_stats(storage_share_objects, return_as='string', memcache
             memcached_ip,
             memcached_port
         )
-
-        # Check if we actually got information
-        if _storage_stats is None:
-            raise dynafed_storagestats.exceptions.MemcachedIndexError()
 
         # Typecast to str if needed. Different versions of memcache module return
         # bytes.

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -210,7 +210,7 @@ def get_currentstats(storage_share_objects, memcached_ip='127.0.0.1', memcached_
 
     except dynafed_storagestats.exceptions.MemcachedError as ERR:
         _logger.error(
-            "Memcache %s Server %s did not return data. All storage_shares will be " \
+            "%s Memcache Server %s did not return data. All storage_shares will be " \
             "assumed 'Online'.",
             ERR.debug,
             memcached_ip + ':' + memcached_port
@@ -235,7 +235,7 @@ def get_currentstats(storage_share_objects, memcached_ip='127.0.0.1', memcached_
 
     except dynafed_storagestats.exceptions.MemcachedError as ERR:
         _logger.error(
-            "Memcache %s Server %s did not return storage status data.",
+            "%s Memcache Server %s did not return storage status data.",
             ERR.debug,
             memcached_ip + ':' + memcached_port
         )

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -81,7 +81,8 @@ def checksums(ARGS):
             _storage_share,
             ARGS.checksum,
             ARGS.hash_type,
-            ARGS.url
+            ARGS.url,
+            force=ARGS.force
         )
 
 

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -261,7 +261,7 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
         )
 
 
-    def put_object_checksum(self, checksum, hash_type, object_url):
+    def put_object_checksum(self, checksum, hash_type, object_url, force=False):
         """Run process to add checksum from object's metadata if it is missing.
 
         This method will first obtain the metadata (if it exists) using the
@@ -296,6 +296,20 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
 
             _logger.info(
                 "[%s]New metadata detected, calling API to upload: %s",
+                self.id,
+                _metadata
+            )
+
+            self.put_object_metadata(_metadata, object_url)
+
+        # Unless the 'force' flag is given
+        elif force:
+            # Update checksum key's value.
+            _metadata[hash_type] = checksum
+            print(_metadata)
+
+            _logger.info(
+                "[%s]Force flag detected, calling API to upload: %s",
                 self.id,
                 _metadata
             )

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -550,6 +550,7 @@ def list_objects(storage_share, delta=1, prefix='',
 
         # Exit if no "NextMarker" as list is now over.
         try:
+            print(_kwargs)
             _kwargs['Marker'] = _response['NextMarker']
         except KeyError:
             break

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.18',
+    version='1.0.19',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
v1.0.19
  ADDED: '-f, --force' flag to checksums put to force checksum metadata update.
  FIXED: Issue when requesting storagestats with the list-objects API only 1000
         objects would be returned for S3 and Azure classes.
  FIXED: Typo on memcahced missing index log line.
  REMOVED: Redundant memcahce empty checks.