### PR TITLE
v1.0.22

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -234,3 +234,8 @@ v1.0.22
            it now first creates a session and from that the client. This is done
            to make the execution multithreding 'safe'. Otherwise the sessoin is
            global and was causing the execution to fail sometimes.
+  ADDED: "-f/--force" flag for "stats" sub-command to skip checks and force
+         stats check.
+  FIXED: Frequency issue that would constantly give wrong stats. Reason was that
+         the check was checking the connectionstats timestamp rather than the
+         storagestats.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -229,3 +229,8 @@ v1.0.20
   ADDED: 'minio_prometheus' api for S3 endpoints.
 v1.0.21
   ADDED: requirement of module 'prometheus_client'
+v1.0.22
+  CHANGED: For s3 boto3 clients, rather than creating the client right away,
+           it now first creates a session and from that the client. This is done
+           to make the execution multithreding 'safe'. Otherwise the sessoin is
+           global and was causing the execution to fail sometimes.

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -273,7 +273,7 @@ def add_reports_subparser(subparser):
     parser.add_argument(
         '-e', '--endpoint',
         action='store',
-        default=['all'],
+        default=[],
         dest='endpoint',
         nargs='*',
         help="Choose endpoint(s) to check. " \
@@ -354,7 +354,7 @@ def add_stats_subparser(subparser):
     parser.add_argument(
         '-e', '--endpoint',
         action='store',
-        default=['all'],
+        default=[],
         dest='endpoint',
         nargs='*',
         help="Choose endpoint(s) to check. " \

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -26,9 +26,6 @@ def parse_args():
     parser = argparse.ArgumentParser()
     subparser = parser.add_subparsers()
 
-    # Options meant to be used by any sub-command
-    add_general_options(parser)
-
     # Sub-command options argument sub-parsers
     add_checksums_subparser(subparser)
     add_reports_subparser(subparser)
@@ -49,6 +46,23 @@ def add_general_options(parser):
     parser -- Object form argparse.ArgumentParser()
 
     """
+    parser.add_argument(
+        '-c', '--config',
+        action='store',
+        default=['/etc/ugr/conf.d'],
+        dest='config_path',
+        nargs='*',
+        help="Path to UGR's endpoint .conf files or directories. " \
+             "Accepts any number of arguments. " \
+             "Default: '/etc/ugr/conf.d'."
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        default=False,
+        dest='verbose',
+        help="Show on stderr events according to loglevel."
+    )
 
 
 def add_checksums_subparser(subparser):
@@ -89,17 +103,11 @@ def add_checkusms_get_subparser(subparser):
     parser.set_defaults(sub_cmd='get')
 
     # General options
-    parser.add_argument(
-        '-c', '--config',
-        action='store',
-        default=['/etc/ugr/conf.d'],
-        dest='config_path',
-        nargs='*',
-        help="Path to UGR's endpoint .conf files or directories. " \
-             "Accepts any number of arguments. " \
-             "Default: '/etc/ugr/conf.d'."
-    )
-    parser.add_argument(
+    add_general_options(parser)
+
+    # Checksum options
+    group_checksum = parser.add_argument_group("Checksum options. Required!")
+    group_checksum.add_argument(
         '-e', '--endpoint',
         action='store',
         default=False,
@@ -107,16 +115,6 @@ def add_checkusms_get_subparser(subparser):
         help="Choose endpoint containing desired object. " \
              "Required."
     )
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        default=False,
-        dest='verbose',
-        help="Show on stderr events according to loglevel."
-    )
-
-    # Checksum options
-    group_checksum = parser.add_argument_group("Checksum options")
     group_checksum.add_argument(
         '-t', '--hash_type',
         action='store',
@@ -135,24 +133,7 @@ def add_checkusms_get_subparser(subparser):
     )
 
     # Logging options
-    group_logging = parser.add_argument_group("Logging options")
-    group_logging.add_argument(
-        '--logfile',
-        action='store',
-        default='/tmp/dynafed_storagestats.log',
-        dest='logfile',
-        help="Set logfile's path. " \
-             "Default: /tmp/dynafed_storagestats.log"
-    )
-    group_logging.add_argument(
-        '--loglevel',
-        action='store',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
-        default='WARNING',
-        dest='loglevel',
-        help="Set log output level. " \
-        "Default: WARNING."
-    )
+    add_logging_options(parser)
 
     # Output Options
     group_output = parser.add_argument_group("Output options")
@@ -183,24 +164,8 @@ def add_checkusms_put_subparser(subparser):
     parser.set_defaults(sub_cmd='put')
 
     # General options
-    parser.add_argument(
-        '-c', '--config',
-        action='store',
-        default=['/etc/ugr/conf.d'],
-        dest='config_path',
-        nargs='*',
-        help="Path to UGR's endpoint .conf files or directories. " \
-             "Accepts any number of arguments. " \
-             "Default: '/etc/ugr/conf.d'."
-    )
-    parser.add_argument(
-        '-e', '--endpoint',
-        action='store',
-        default=False,
-        dest='endpoint',
-        help="Choose endpoint containing desired object. " \
-             "Required."
-    )
+    add_general_options(parser)
+
     parser.add_argument(
         '-f', '--force',
         action='store_true',
@@ -209,16 +174,9 @@ def add_checkusms_put_subparser(subparser):
         help="Force checksum to be put. " \
              "Default: 'False'."
     )
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        default=False,
-        dest='verbose',
-        help="Show on stderr events according to loglevel."
-    )
 
     # Checksum options
-    group_checksum = parser.add_argument_group("Checksum options")
+    group_checksum = parser.add_argument_group("Checksum options. Required!")
     group_checksum.add_argument(
         '--checksum',
         action='store',
@@ -226,6 +184,14 @@ def add_checkusms_put_subparser(subparser):
         dest='checksum',
         help="String with checksum to set. ['adler32', md5] " \
              "Required"
+    )
+    group_checksum.add_argument(
+        '-e', '--endpoint',
+        action='store',
+        default=False,
+        dest='endpoint',
+        help="Choose endpoint containing desired object. " \
+             "Required."
     )
     group_checksum.add_argument(
         '-t', '--hash_type',
@@ -245,24 +211,7 @@ def add_checkusms_put_subparser(subparser):
     )
 
     # Logging options
-    group_logging = parser.add_argument_group("Logging options")
-    group_logging.add_argument(
-        '--logfile',
-        action='store',
-        default='/tmp/dynafed_storagestats.log',
-        dest='logfile',
-        help="Set logfile's path. " \
-             "Default: /tmp/dynafed_storagestats.log"
-    )
-    group_logging.add_argument(
-        '--loglevel',
-        action='store',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
-        default='WARNING',
-        dest='loglevel',
-        help="Set log output level. " \
-        "Default: WARNING."
-    )
+    add_logging_options(parser)
 
     # Output Options
     group_output = parser.add_argument_group("Output options")
@@ -276,61 +225,13 @@ def add_checkusms_put_subparser(subparser):
     )
 
 
-def add_reports_subparser(subparser):
-    """Add optional arguments for the 'reports' sub-command.
+def add_logging_options(parser):
+    """Add logging optional arguments.
 
     Arguments:
-    subparser -- Object form argparse.ArgumentParser().add_subparsers()
+    parser -- Object form argparse.ArgumentParser()
 
     """
-    # Initiate parser.
-    parser = subparser.add_parser(
-        'reports',
-        help="In development"
-    )
-
-    # Set the sub-command routine to run.
-    parser.set_defaults(cmd='reports')
-
-    # Set the sub-command routine to run.
-    # General options
-    parser.add_argument(
-        '-c', '--config',
-        action='store',
-        default=['/etc/ugr/conf.d'],
-        dest='config_path',
-        nargs='*',
-        help="Path to UGR's endpoint .conf files or directories. " \
-             "Accepts any number of arguments. " \
-             "Default: '/etc/ugr/conf.d'."
-    )
-    parser.add_argument(
-        '--delta',
-        action='store',
-        default=1,
-        dest='delta',
-        type=int,
-        help="Mask for Last Modified Date of files. Integer in days. " \
-             "Default: 1"
-    )
-    parser.add_argument(
-        '-e', '--endpoint',
-        action='store',
-        default=['all'],
-        dest='endpoint',
-        nargs='*',
-        help="Choose endpoint(s) to check. " \
-             "Accepts any number of arguments. "
-             "If not present, all endpoints will be checked."
-    )
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        default=False,
-        dest='verbose',
-        help="Show on stderr events according to loglevel."
-    )
-
     # Logging options
     group_logging = parser.add_argument_group("Logging options")
     group_logging.add_argument(
@@ -350,6 +251,51 @@ def add_reports_subparser(subparser):
         help="Set log output level. " \
         "Default: WARNING."
     )
+
+
+def add_reports_subparser(subparser):
+    """Add optional arguments for the 'reports' sub-command.
+
+    Arguments:
+    subparser -- Object form argparse.ArgumentParser().add_subparsers()
+
+    """
+    # Initiate parser.
+    parser = subparser.add_parser(
+        'reports',
+        help="In development"
+    )
+
+    # Set the sub-command routine to run.
+    parser.set_defaults(cmd='reports')
+
+    # General options
+    add_general_options(parser)
+
+    parser.add_argument(
+        '-e', '--endpoint',
+        action='store',
+        default=['all'],
+        dest='endpoint',
+        nargs='*',
+        help="Choose endpoint(s) to check. " \
+             "Accepts any number of arguments. "
+             "If not present, all endpoints will be checked."
+    )
+
+    group_reports = parser.add_argument_group("Reports options")
+    group_reports.add_argument(
+        '--delta',
+        action='store',
+        default=1,
+        dest='delta',
+        type=int,
+        help="Mask for Last Modified Date of files. Integer in days. " \
+             "Default: 1"
+    )
+
+    # Logging options
+    add_logging_options(parser)
 
     # Output Options
     group_output = parser.add_argument_group("Output options")
@@ -405,16 +351,8 @@ def add_stats_subparser(subparser):
     parser.set_defaults(cmd='stats')
 
     # General options
-    parser.add_argument(
-        '-c', '--config',
-        action='store',
-        default=['/etc/ugr/conf.d'],
-        dest='config_path',
-        nargs='*',
-        help="Path to UGR's endpoint .conf files or directories. " \
-             "Accepts any number of arguments. " \
-             "Default: '/etc/ugr/conf.d'."
-    )
+    add_general_options(parser)
+
     parser.add_argument(
         '-e', '--endpoint',
         action='store',
@@ -425,33 +363,9 @@ def add_stats_subparser(subparser):
              "Accepts any number of arguments. "
              "If not present, all endpoints will be checked."
     )
-    parser.add_argument(
-        '-v', '--verbose',
-        action='store_true',
-        default=False,
-        dest='verbose',
-        help="Show on stderr events according to loglevel."
-    )
 
     # Logging options
-    group_logging = parser.add_argument_group("Logging options")
-    group_logging.add_argument(
-        '--logfile',
-        action='store',
-        default='/tmp/dynafed_storagestats.log',
-        dest='logfile',
-        help="Set logfile's path. " \
-             "Default: /tmp/dynafed_storagestats.log"
-    )
-    group_logging.add_argument(
-        '--loglevel',
-        action='store',
-        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
-        default='WARNING',
-        dest='loglevel',
-        help="Set log output level. " \
-        "Default: WARNING."
-    )
+    add_logging_options(parser)
 
     # Memcached Options
     group_memcached = parser.add_argument_group("Memcached Options")
@@ -525,14 +439,14 @@ def add_stats_subparser(subparser):
         help="Set to output stats on stdout."
     )
 
-    group_output.add_argument(
-        '-x', '--xml',
-        action='store',
-        const="dynafed_storagestats.xml",
-        default=False,
-        dest='output_xml',
-        nargs='?',
-        help="Set to output stats to json file. Add argument to set filename." \
-             "Default: dynafed_storagestats.json"
-             "!!In development!!"
-    )
+    # group_output.add_argument(
+    #     '-x', '--xml',
+    #     action='store',
+    #     const="dynafed_storagestats.xml",
+    #     default=False,
+    #     dest='output_xml',
+    #     nargs='?',
+    #     help="Set to output stats to json file. Add argument to set filename." \
+    #          "Default: dynafed_storagestats.json"
+    #          "!!In development!!"
+    # )

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -57,6 +57,13 @@ def add_general_options(parser):
              "Default: '/etc/ugr/conf.d'."
     )
     parser.add_argument(
+        '-f', '--force',
+        action='store_true',
+        default=False,
+        dest='force',
+        help="Force command execution."
+    )
+    parser.add_argument(
         '-v', '--verbose',
         action='store_true',
         default=False,
@@ -165,15 +172,6 @@ def add_checkusms_put_subparser(subparser):
 
     # General options
     add_general_options(parser)
-
-    parser.add_argument(
-        '-f', '--force',
-        action='store_true',
-        default=False,
-        dest='force',
-        help="Force checksum to be put. " \
-             "Default: 'False'."
-    )
 
     # Checksum options
     group_checksum = parser.add_argument_group("Checksum options. Required!")

--- a/dynafed_storagestats/exceptions.py
+++ b/dynafed_storagestats/exceptions.py
@@ -163,6 +163,18 @@ class ConfigFileErrorNoConfigFilesFound(ConfigFileError):
 
         super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
 
+class ConfigFileErrorNoEndpointsFound(ConfigFileError):
+    """
+    Exception error when no endpoints are found in the configuration files.
+    """
+    def __init__(self, config_path, error="NoEndpointsFound", status_code="00?", debug=None):
+
+        self.message = 'No endpoints found in configuration file(s): %s' \
+                       % (config_path)
+        self.debug = debug
+
+        super().__init__(error=error, status_code=status_code, message=self.message, debug=self.debug)
+
 class MemcachedError(BaseError):
     """
     Base error exception subclass for issues deailng with memcached

--- a/dynafed_storagestats/helpers.py
+++ b/dynafed_storagestats/helpers.py
@@ -60,7 +60,7 @@ def check_frequency(storage_share_objects, stats):
     Arguments:
     storage_share_objects -- list of dynafed_storagestats StorageShare objects.
     stats -- dictionary of storage_shares and their status obtained from
-             get_cached_connection_stats with return_as='expanded_dictionary'.
+             get_cached_storage_stats with return_as='expanded_dictionary'.
 
     """
     ############# Creating loggers ################

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -186,8 +186,8 @@ def stats(ARGS):
         output.to_stdout(storage_endpoints, ARGS)
 
     # Create StAR Storagestats XML files for each storage share.
-    if ARGS.output_xml:
-        output.to_xml(storage_endpoints, ARGS.to_xml, ARGS.output_path)
+    # if ARGS.output_xml:
+    #     output.to_xml(storage_endpoints, ARGS.to_xml, ARGS.output_path)
 
     # Create json file with storagestats
     if ARGS.to_json:

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -140,23 +140,25 @@ def stats(ARGS):
         ARGS.config_path
     )
 
-    # Obtain current stats, if any, from memcached.
-    _connection_stats, _storage_stats = helpers.get_currentstats(
-        storage_shares,
-        ARGS.memcached_ip,
-        ARGS.memcached_port
-    )
+    # Skip checks of '-f/--force' flag is set.
+    if not ARGS.force:
+        # Obtain current stats, if any, from memcached.
+        _connection_stats, _storage_stats = helpers.get_currentstats(
+            storage_shares,
+            ARGS.memcached_ip,
+            ARGS.memcached_port
+        )
 
-    if _connection_stats is not None:
-        # Flag storage shares that have been marked offline by Dynafed.
-        helpers.check_connectionstats(storage_shares, _connection_stats)
+        if _connection_stats is not None:
+            # Flag storage shares that have been marked offline by Dynafed.
+            helpers.check_connectionstats(storage_shares, _connection_stats)
 
-        # Flag storage shares that are under-due their period.
-        helpers.check_frequency(storage_shares, _connection_stats)
+        if _storage_stats is not None:
+            # Flag storage shares that are under-due their period.
+            helpers.check_frequency(storage_shares, _storage_stats)
 
-    if _storage_stats is not None:
-        # Update storage_share objects with information obtaines from memcache.
-        helpers.update_storage_share_storagestats(storage_shares, _storage_stats)
+            # Update storage_share objects with information obtained from memcache.
+            helpers.update_storage_share_storagestats(storage_shares, _storage_stats)
 
     # Create a list of StorageEndpoint objects with the StorageShares to check,
     # based on user input or unique URL's.

--- a/dynafed_storagestats/runner.py
+++ b/dynafed_storagestats/runner.py
@@ -53,37 +53,29 @@ def checksums(ARGS):
 
     # Get list of StorageShare objects from the configuration files.
     _storage_shares = configloader.get_storage_shares(
-        ARGS.config_path
-    )
-
-    # Create a list of StorageEndpoint objects with the StorageShares and
-    # select the one chosen from CLI.
-    _storage_endpoints = configloader.get_storage_endpoints(
-        _storage_shares,
+        ARGS.config_path,
         ARGS.endpoint
     )
 
-    # Extract the requested storage_share.
-    _storage_share = _storage_endpoints[0].storage_shares[0]
+    for _storage_share in _storage_shares:
+        # Process the requested checksum action for file/object.
+        if ARGS.sub_cmd == 'get':
+            _checksum = helpers.process_checksums_get(
+                _storage_share,
+                ARGS.hash_type,
+                ARGS.url
+            )
 
-    # Process the requested checksum action for file/object.
-    if ARGS.sub_cmd == 'get':
-        _checksum = helpers.process_checksums_get(
-            _storage_share,
-            ARGS.hash_type,
-            ARGS.url
-        )
+            print(_checksum)
 
-        print(_checksum)
-
-    elif ARGS.sub_cmd == 'put':
-        helpers.process_checksums_put(
-            _storage_share,
-            ARGS.checksum,
-            ARGS.hash_type,
-            ARGS.url,
-            force=ARGS.force
-        )
+        elif ARGS.sub_cmd == 'put':
+            helpers.process_checksums_put(
+                _storage_share,
+                ARGS.checksum,
+                ARGS.hash_type,
+                ARGS.url,
+                force=ARGS.force
+            )
 
 
 def reports(ARGS):
@@ -97,14 +89,14 @@ def reports(ARGS):
     """
     # Get list of StorageShare objects from the configuration files.
     storage_shares = configloader.get_storage_shares(
-        ARGS.config_path
+        ARGS.config_path,
+        ARGS.endpoint
     )
 
     # Create a list of StorageEndpoint objects with the StorageShares to check,
     # based on user input or unique URL's.
     storage_endpoints = configloader.get_storage_endpoints(
-        storage_shares,
-        ARGS.endpoint
+        storage_shares
     )
 
     # This tuple is necessary for the starmap function to send multiple
@@ -137,7 +129,8 @@ def stats(ARGS):
     """
     # Get list of StorageShare objects from the configuration files.
     storage_shares = configloader.get_storage_shares(
-        ARGS.config_path
+        ARGS.config_path,
+        ARGS.endpoint
     )
 
     # Skip checks of '-f/--force' flag is set.
@@ -163,8 +156,7 @@ def stats(ARGS):
     # Create a list of StorageEndpoint objects with the StorageShares to check,
     # based on user input or unique URL's.
     storage_endpoints = configloader.get_storage_endpoints(
-        storage_shares,
-        ARGS.endpoint
+        storage_shares
     )
 
     # This tuple is necessary for the starmap function to send multiple

--- a/dynafed_storagestats/s3/base.py
+++ b/dynafed_storagestats/s3/base.py
@@ -310,7 +310,6 @@ class S3StorageShare(dynafed_storagestats.base.StorageShare):
         elif force:
             # Update checksum key's value.
             _metadata[hash_type] = checksum
-            print(_metadata)
 
             _logger.info(
                 "[%s]Force flag detected, calling API to upload: %s",

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -367,7 +367,7 @@ def cloudwatch(storage_share):
 
 
 def get_cloudwatch_boto_client(storage_share):
-        """Return boto client from storage share object.
+        """Generate unique session Cloudwatch boto client from storage share object.
 
         Arguments:
         storage_share -- dynafed_storagestats StorageShare object.
@@ -376,8 +376,12 @@ def get_cloudwatch_boto_client(storage_share):
         botocore.client.cloudwatch
 
         """
+
+        # Generate a new session. Needed when running in multithreading.
+        _session = boto3.session.Session()
+
         # Generate boto client to query AWS API.
-        _connection = boto3.client(
+        _connection = _session.client(
             'cloudwatch',
             region_name=storage_share.plugin_settings['s3.region'],
             aws_access_key_id=storage_share.plugin_settings['s3.pub_key'],
@@ -395,7 +399,7 @@ def get_cloudwatch_boto_client(storage_share):
 
 
 def get_s3_boto_client(storage_share):
-        """Return boto client from storage share object.
+        """Generate unique session S3 boto client from storage share object.
 
         Arguments:
         storage_share -- dynafed_storagestats StorageShare object.
@@ -419,8 +423,11 @@ def get_s3_boto_client(storage_share):
                 domain=storage_share.uri['domain']
             )
 
+        # Generate a new session. Needed when running in multithreading.
+        _session = boto3.session.Session()
+
         # Generate boto client to query S3 endpoint.
-        _connection = boto3.client(
+        _connection = _session.client(
             's3',
             region_name=storage_share.plugin_settings['s3.region'],
             endpoint_url=_api_url,
@@ -473,13 +480,13 @@ def list_objects(storage_share, delta=1, prefix='',
         'Prefix': prefix,
     }
 
-    _logger.debug(
-        "[%s]Requesting storage stats with: URN: %s API Method: %s Payload: %s",
-        storage_share.id,
-        _connection._endpoint,
-        storage_share.plugin_settings['storagestats.api'].lower(),
-        _kwargs
-    )
+    # _logger.debug(
+    #     "[%s]Requesting storage stats with: URN: %s API Method: %s Payload: %s",
+    #     storage_share.id,
+    #     _connection._endpoint,
+    #     storage_share.plugin_settings['storagestats.api'].lower(),
+    #     _kwargs
+    # )
 
     # This loop is needed to obtain all objects as the API can only
     # server 1,000 objects per request. The 'NextMarker' tells where

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(PWD, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='dynafed_storagestats',
-    version='1.0.21',
+    version='1.0.22',
     description='Dynafed Storage Stats Module',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
v1.0.22
  CHANGED: For s3 boto3 clients, rather than creating the client right away, it now first creates a session and from that the client. This is done to make the execution multithreding 'safe'. Otherwise the sessoin is global and was causing the execution to fail sometimes.
  ADDED: "-f/--force" flag for "stats" sub-command to skip checks and force stats check.
  FIXED: Frequency issue that would constantly give wrong stats. Reason was that the check was checking the connectionstats timestamp rather than the storagestats.
  CHANGED: How storage endopints are read from the configuration files, moved this selection process from get_storage_endpoints() to get_storage_shares().
  ADDED: Added checks and exception handling for when no entpoinds are found.