### PR TITLE
V1.0.24

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -246,3 +246,9 @@ v1.0.22
 v1.0.23
   ADDED: '--version' flag.
   FIXED: Some numerical stats were failing to be integer type.
+v1.0.24
+  ADDED: '--rucio' flag to 'reports filelist' that sets the prefix='rucio' and
+         delta='1' used for rucio consistency check filedumps.
+  ADDED: '--wlcg' flag to 'reports storage' that generates a jsonf file according
+         to WLCG's storage accounting format from spcified site schema file.
+  CHANGE: The reports file list now removes the chosen prefix from the paths.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ fernando@ffgalindo:/tmp/dd»
 ---
 
 ##### Reports
+
+The reports sub-command has two sub-commands itself:
+
+###### *filelist*
 **Note: Only works with Azure and S3 endpoints**
 
 This sub-command is intended to be used to obtain file reports from the storage
@@ -196,17 +200,20 @@ prefix that are a day older from endpoints 'entpoint1' and 'endpoint2'. The
 filename is the endpoint's ID name in the endpoints.conf file.
 
 ```bash
-dynafed-storage reports -c ~/lab/dynafed_storagestats/tests/local/ -o /tmp/delete --delta 1 -p rucio -e endpoint1 endpoint2
+dynafed-storage reports filelist -c /etc/ugr/conf.d -o /tmp --rucio -e endpoint1 endpoint2
 ```
 
-**reports help:**
+**reports filelist help:**
 ```bash
-dynafed-storage reports --help
-usage: dynafed-storage reports [-h] [-c [CONFIG_PATH [CONFIG_PATH ...]]] [-f]
-                               [-v] [-e [ENDPOINT [ENDPOINT ...]]]
-                               [--delta DELTA] [--logfile LOGFILE]
-                               [--loglevel {DEBUG,INFO,WARNING,ERROR}]
-                               [-o OUTPUT_PATH] [-p PREFIX]
+dynafed-storage reports filelist -h
+usage: dynafed-storage reports filelist [-h]
+                                        [-c [CONFIG_PATH [CONFIG_PATH ...]]]
+                                        [-f] [-v]
+                                        [-e [ENDPOINT [ENDPOINT ...]]]
+                                        [--logfile LOGFILE]
+                                        [--loglevel {DEBUG,INFO,WARNING,ERROR}]
+                                        [--delta DELTA] [--rucio]
+                                        [-o OUTPUT_PATH] [-p PREFIX]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -221,22 +228,26 @@ optional arguments:
                         arguments. If not present, all endpoints will be
                         checked.
 
-Reports options:
-  --delta DELTA         Mask for Last Modified Date of files. Integer in days.
-                        Default: 1
-
 Logging options:
   --logfile LOGFILE     Set logfiles path. Default:
                         /tmp/dynafed_storagestats.log
   --loglevel {DEBUG,INFO,WARNING,ERROR}
                         Set log output level. Default: WARNING.
 
+Reports options:
+  --delta DELTA         Mask for Last Modified Date of files. Integer in days.
+                        Default: 1
+  --rucio               Use to create rucio file dumps for consitency checks.
+                        Same as: --delta 1 --prefix rucio
+
 Output options:
   -o OUTPUT_PATH, --output-dir OUTPUT_PATH
                         Set output directory. Default: '.'
   -p PREFIX, --path PREFIX, --prefix PREFIX
                         Set the prefix/path from where to start the recursive
-                        list.Default: ''
+                        list. The prefix is excluded from the resulting paths.
+                        Default: ''
+
 
 ```
 **Important Note: DEBUG level might print an enormous amount of data as it will
@@ -244,9 +255,68 @@ log the contents obtained from requests. In the case of the generic methods this
 will print all the stats for each file being parsed. It is recommended to use
 this level with only the endpoint one wants to troubleshoot.**
 
+###### *storage*
+
+The purpose of this sub-command is to create storage accounting reports according
+to different formats that experiments might require.
+
+At the moment only WLCG's JSON storage accounting file is available.
+
+In order to create it, the user will have to create a 'site-schema' YAML file
+containing the site information. Please check in the 'samples' folder for
+examples on how to create these file. The '-s/--schema' flag is required and
+should point to this site-schema file.
+
+Usage example:
+This will create file '/tmp/space-usage.json'
+
+```bash
+dynafed-storage reports storage --wlcg -c /etc/ugr/conf.d -s wlcg-schema.yml -o /tmp
+```
+
+**reports storage help:**
+```bash
+dynafed-storage reports storage -h
+usage: dynafed-storage reports storage [-h]
+                                       [-c [CONFIG_PATH [CONFIG_PATH ...]]]
+                                       [-f] [-v]
+                                       [-e [ENDPOINT [ENDPOINT ...]]]
+                                       [--logfile LOGFILE]
+                                       [--loglevel {DEBUG,INFO,WARNING,ERROR}]
+                                       [-s SCHEMA] [--wlcg] [-o OUTPUT_PATH]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c [CONFIG_PATH [CONFIG_PATH ...]], --config [CONFIG_PATH [CONFIG_PATH ...]]
+                        Path to UGRs endpoint .conf files or directories.
+                        Accepts any number of arguments. Default:
+                        '/etc/ugr/conf.d'.
+  -f, --force           Force command execution.
+  -v, --verbose         Show on stderr events according to loglevel.
+  -e [ENDPOINT [ENDPOINT ...]], --endpoint [ENDPOINT [ENDPOINT ...]]
+                        Choose endpoint(s) to check. Accepts any number of
+                        arguments. If not present, all endpoints will be
+                        checked.
+
+Logging options:
+  --logfile LOGFILE     Set logfiles path. Default:
+                        /tmp/dynafed_storagestats.log
+  --loglevel {DEBUG,INFO,WARNING,ERROR}
+                        Set log output level. Default: WARNING.
+
+Reports options:
+  -s SCHEMA, --schema SCHEMA
+                        YAML file containing site schema. Required.
+  --wlcg                Produces WLCG JSON output file. Requires setup file.
+
+Output options:
+  -o OUTPUT_PATH, --output-dir OUTPUT_PATH
+                        Set output directory. Default: '.'
+```
+
 ---
 
-##### Stats
+##### stats
 
 This sub-command is intended to be run periodically as a cron job in order to
 upload the stats into memcached so that Dynafed can use it to be aware of the

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -61,7 +61,7 @@ def add_general_options(parser):
         default=['/etc/ugr/conf.d'],
         dest='config_path',
         nargs='*',
-        help="Path to UGR's endpoint .conf files or directories. " \
+        help="Path to UGRs endpoint .conf files or directories. " \
              "Accepts any number of arguments. " \
              "Default: '/etc/ugr/conf.d'."
     )
@@ -98,6 +98,7 @@ def add_checksums_subparser(subparser):
     # Set the sub-command routine to run.
     parser.set_defaults(cmd='checksums')
 
+    # Add Sub-sub commands
     add_checkusms_get_subparser(subparser)
     add_checkusms_put_subparser(subparser)
 
@@ -246,7 +247,7 @@ def add_logging_options(parser):
         action='store',
         default='/tmp/dynafed_storagestats.log',
         dest='logfile',
-        help="Set logfile's path. " \
+        help="Set logfiles path. " \
              "Default: /tmp/dynafed_storagestats.log"
     )
     group_logging.add_argument(
@@ -270,11 +271,33 @@ def add_reports_subparser(subparser):
     # Initiate parser.
     parser = subparser.add_parser(
         'reports',
-        help="In development"
+        help="Generate report files."
     )
+    subparser = parser.add_subparsers()
 
     # Set the sub-command routine to run.
     parser.set_defaults(cmd='reports')
+
+    # Add Sub-sub commands
+    add_reports_filelist_subparser(subparser)
+    add_reports_storage_subparser(subparser)
+
+
+def add_reports_filelist_subparser(subparser):
+    """Add optional arguments for the 'reports filelist' sub-command.
+
+    Arguments:
+    subparser -- Object form argparse.ArgumentParser().add_subparsers()
+
+    """
+    # Initiate parser.
+    parser = subparser.add_parser(
+        'filelist',
+        help="Generate file-list related report."
+    )
+
+    # Set the sub-command routine to run.
+    parser.set_defaults(sub_cmd='filelist')
 
     # General options
     add_general_options(parser)
@@ -290,6 +313,10 @@ def add_reports_subparser(subparser):
              "If not present, all endpoints will be checked."
     )
 
+    # Logging options
+    add_logging_options(parser)
+
+    # Reports options
     group_reports = parser.add_argument_group("Reports options")
     group_reports.add_argument(
         '--delta',
@@ -300,9 +327,14 @@ def add_reports_subparser(subparser):
         help="Mask for Last Modified Date of files. Integer in days. " \
              "Default: 1"
     )
-
-    # Logging options
-    add_logging_options(parser)
+    group_reports.add_argument(
+        '--rucio',
+        action='store_true',
+        default=False,
+        dest='rucio',
+        help="Use to create rucio file dumps for consitency checks. " \
+             "Same as: --delta 1 --prefix rucio"
+    )
 
     # Output Options
     group_output = parser.add_argument_group("Output options")
@@ -336,8 +368,87 @@ def add_reports_subparser(subparser):
         action='store',
         default='',
         dest='prefix',
-        help="Set the prefix/path from where to start the recursive list." \
-             "Default: ''"
+        help="Set the prefix/path from where to start the recursive list. " \
+             "The prefix is excluded from the resulting paths. Default: ''"
+    )
+
+
+def add_reports_storage_subparser(subparser):
+    """Add optional arguments for the 'reports storage' sub-command.
+
+    Arguments:
+    subparser -- Object form argparse.ArgumentParser().add_subparsers()
+
+    """
+    # Initiate parser.
+    parser = subparser.add_parser(
+        'storage',
+        help="Generate storage related report."
+    )
+
+    # Set the sub-command routine to run.
+    parser.set_defaults(sub_cmd='storage')
+
+    # General options
+    add_general_options(parser)
+
+    parser.add_argument(
+        '-e', '--endpoint',
+        action='store',
+        default=[],
+        dest='endpoint',
+        nargs='*',
+        help="Choose endpoint(s) to check. " \
+             "Accepts any number of arguments. "
+             "If not present, all endpoints will be checked."
+    )
+
+    # Logging options
+    add_logging_options(parser)
+
+    # Reports options
+    group_reports = parser.add_argument_group("Reports options")
+    group_reports.add_argument(
+        '-s','--schema',
+        action='store',
+        default=False,
+        dest='schema',
+        help="YAML file containing site schema. Required." \
+    )
+    group_reports.add_argument(
+        '--wlcg',
+        action='store_true',
+        default=False,
+        dest='wlcg',
+        help="Produces WLCG JSON output file. Requires setup file." \
+    )
+
+    # Output Options
+    group_output = parser.add_argument_group("Output options")
+    # group_output.add_argument(
+    #     '--debug',
+    #     action='store_true',
+    #     default=False,
+    #     dest='debug',
+    #     help="Declare to enable debug output on stdout."
+    # )
+
+    # group_output.add_argument(
+    #     '-f', '--filename',
+    #     action='store',
+    #     default='report.txt',
+    #     dest='report_filename',
+    #     help="Set output filename. " \
+    #          "Default: 'report_filename'"
+    # )
+
+    group_output.add_argument(
+        '-o', '--output-dir',
+        action='store',
+        default='.',
+        dest='output_path',
+        help="Set output directory. " \
+             "Default: '.'"
     )
 
 

--- a/dynafed_storagestats/json.py
+++ b/dynafed_storagestats/json.py
@@ -76,7 +76,7 @@ def format_wlcg(storage_endpoints, hostname="localhost"):
         # 'servicetype': "tbd",
         "implementation": "dynafed",
         # 'implementationversion': "tbd",
-        "latesupdate": int(datetime.datetime.now().timestamp()),
+        "latestupdate": int(datetime.datetime.now().timestamp()),
         "storageservicecapacity": {
             "totalsize": _dynafed_totalsize,
             "usedsize": _dynafed_usedsize,

--- a/dynafed_storagestats/reports.py
+++ b/dynafed_storagestats/reports.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+"""Functions to generate storage reports."""
+
+import json
+import logging
+import time
+import sys
+
+#############
+# Functions #
+#############
+
+def create_wlcg_storage_report(dynafed_endpoints, schema, output='/tmp'):
+    """Creates json file according to the WLCG storage report format.
+
+    """
+    ############# Creating loggers ################
+    _logger = logging.getLogger(__name__)
+    ###############################################
+
+    _output_file = output + '/space-usage.json'
+
+    # Getting current timestamp
+    NOW = int(time.time())
+
+    # Calculate the totals space and used space for each of the dynafed endpoints
+    # under each storage share.
+    for _schema_storage_service in schema['storageservice']:
+        for _schema_storage_share in _schema_storage_service['storageshares']:
+            bytes_used = 0
+            total_size = 0
+            for _dynafed_endpoint in _schema_storage_share['dynafedendpoints']:
+
+                _id = _dynafed_endpoint
+
+                for _endpoint in dynafed_endpoints:
+                    if _endpoint.id == _id:
+                        bytes_used +=_endpoint.stats['bytesused']
+                        total_size += _endpoint.stats['quota']
+
+            _schema_storage_share.update(
+                {
+                    "totalsize": total_size,
+                    "timestamp": NOW,
+                    "usedsize": bytes_used,
+                }
+            )
+            del _schema_storage_share['dynafedendpoints']
+
+    # Create the json structure
+    # skeleton = {
+    #     'storage_service': {
+    #         'latestupdate': NOW,
+    #         'name': dynafed_hostname,
+    #         'storage_shares': storage_shares
+    #     }
+    # }
+
+    # Ouptut json to file.
+    with open(_output_file, 'w') as json_file:
+        json.dump(schema, json_file, indent=4, sort_keys=True)

--- a/dynafed_storagestats/s3/helpers.py
+++ b/dynafed_storagestats/s3/helpers.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+import os
 
 import boto3
 import botocore.vendored.requests.exceptions as botoRequestsExceptions
@@ -448,7 +449,7 @@ def get_s3_boto_client(storage_share):
 
 
 def list_objects(storage_share, delta=1, prefix='',
-                 report_file='/tmp/filelist_report.txt',
+                 report_file='/tmp/filelist_report',
                  request='storagestats'
                  ):
     """Contact S3 endpoint using list_objects API.
@@ -538,7 +539,11 @@ def list_objects(storage_share, delta=1, prefix='',
                 for _file in _response['Contents']:
                     # Output files older than the specified delta.
                     if dynafed_storagestats.time.mask_timestamp_by_delta(_file['LastModified'], delta):
-                        report_file.write("%s\n" % _file['Key'])
+                        # Remove the prefix:
+                        _filepath = os.path.relpath(_file['Key'], prefix)
+                        # Write to file
+                        report_file.write("%s\n" % _filepath)
+                        # File counter
                         _total_files += 1
 
         # Exit if no "NextMarker" as list is now over.

--- a/dynafed_storagestats/version.py
+++ b/dynafed_storagestats/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
-__version__ = "1.0.23"
+__version__ = "1.0.24"

--- a/samples/wlcg-min-schema.yml
+++ b/samples/wlcg-min-schema.yml
@@ -1,0 +1,19 @@
+storageservice:
+  - name: "your.dynafed.com"
+    storageshares:
+      # Example storage share. Change names, path and endpoints as needed.
+      - name: "ATLASDATADISK"
+        path:
+          - "dynafed/atlas/atlasdatadisk"
+        dynafedendpoints:
+          # Add here the endpoints' UGR ID's
+          - "ENDPOINT01_ID"
+          - "ENDPOINT02_ID"
+
+      # Example to show how to add more storage shares.
+      - name: "ATLASSCRATCHDISK"
+        path:
+          - "dynafed/atlas/atlasscratchdisk"
+        dynafedendpoints:
+          - "ENDPOINT03_ID"
+          - "ENDPOINT04_ID"


### PR DESCRIPTION
v1.0.24
ADDED: '--rucio' flag to 'reports filelist' that sets the prefix='rucio' and delta='1' used for rucio consistency check filedumps.
ADDED: '--wlcg' flag to 'reports storage' that generates a jsonf file according to WLCG's storage accounting format from spcified site schema file.
CHANGE: The reports file list now removes the chosen prefix from the paths.