### PR TITLE
v1.0.26

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -254,3 +254,6 @@ v1.0.24
   CHANGE: The reports file list now removes the chosen prefix from the paths.
 v1.0.25
   ADDED: Requirement of PyYAML.
+v1.0.26
+  ADDED: type=str.lower to make sure checksums and checksums types are always
+         lowercase.

--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -113,7 +113,7 @@ def add_checkusms_get_subparser(subparser):
     # Initiate parser.
     parser = subparser.add_parser(
         'get',
-        help="Get object/file checksums.."
+        help="Get object/file checksums."
     )
 
     # Set the sub-command routine to run.
@@ -137,6 +137,7 @@ def add_checkusms_get_subparser(subparser):
         action='store',
         default=False,
         dest='hash_type',
+        type=str.lower,
         help="Type of checksum hash. ['adler32', md5] " \
              "Required."
     )
@@ -190,6 +191,7 @@ def add_checkusms_put_subparser(subparser):
         action='store',
         default=False,
         dest='checksum',
+        type=str.lower,
         help="String with checksum to set. ['adler32', md5] " \
              "Required"
     )
@@ -206,6 +208,7 @@ def add_checkusms_put_subparser(subparser):
         action='store',
         default=False,
         dest='hash_type',
+        type=str.lower,
         help="Type of checksum hash. ['adler32', md5] " \
              "Required."
     )

--- a/dynafed_storagestats/version.py
+++ b/dynafed_storagestats/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
-__version__ = "1.0.25"
+__version__ = "1.0.26"


### PR DESCRIPTION
v1.0.26
  ADDED: type=str.lower to make sure checksums and checksums types are always lowercase.