### PR TITLE
Fixes for checksum args and ssl_check ca_path settings

### DIFF
--- a/dynafed_storagestats/args.py
+++ b/dynafed_storagestats/args.py
@@ -131,7 +131,9 @@ def add_checkusms_get_subparser(subparser):
         action='store',
         default=False,
         dest='endpoint',
-        type=list,
+        nargs='+',
+        required=True,
+        type=str,
         help="Choose endpoint containing desired object. "
              "Required."
     )
@@ -140,6 +142,7 @@ def add_checkusms_get_subparser(subparser):
         action='store',
         default=False,
         dest='hash_type',
+        required=True,
         type=str.lower,
         help="Type of checksum hash. ['adler32', md5] "
              "Required."
@@ -148,6 +151,7 @@ def add_checkusms_get_subparser(subparser):
         '-u', '--url',
         action='store',
         default=False,
+        required=True,
         dest='url',
         help="URL of object/file to request checksum of. "
              "Required."

--- a/dynafed_storagestats/base.py
+++ b/dynafed_storagestats/base.py
@@ -252,12 +252,15 @@ class StorageShare():
 
         # If user has specified an SSL CA bundle:
         if self.plugin_settings['ssl_check']:
-            try:
+            # If there is a specific 'storagestats.ca_path' setting then we use that.
+            # Useful to specify a different bundle file when Dynafed/gridsite wants a certificates directory
+            if 'storagestats.ca_path' in self.plugin_settings:
+                self.plugin_settings['ssl_check'] = self.plugin_settings['storagestats.ca_path']
+            # If the ca_path is in the UGR settings we try to use that
+            elif 'ca_path' in self.plugin_settings:
                 self.plugin_settings['ssl_check'] = self.plugin_settings['ca_path']
 
-            except KeyError:
-                # The ssl_check will stay True and standard CA bundle will be used.
-                pass
+            # If neither setting is available then ssl_check will stay True and standard CA bundle will be used.
 
         # Check the quota setting and transform it into bytes if necessary.
         if self.plugin_settings['storagestats.quota'] != "api":


### PR DESCRIPTION
The way that the ssl_check/ca_path settings currently work for S3 can be problematic when attempting to use the standard gridsite certificates directory e.g. /etc/grid-security/certificates

Dynafed and gridsite's config wants a certificate directory, whereas the Python boto3 S3 client needs a certificate bundle file. You can bundle your certificates into a file via the `update-ca-trust` command, however `dynafed-storagestats` takes the `ca_path` from your UGR config settings which basically has to be a certificates directory for the rest of Dynafed to work with the grid. 

The change below allows a `'storagestats.ca_path'` setting in the endpoint config so that you can set a bundle file for use with boto3, while Dynafed can separately set it's `ca_path` to a certificates directory. If this setting doesn't exist then it will fall back to using the overall `ca_path` (which is the current behaviour), and then fall back to the standard Python SSL bundle as before if no ca_path is set.

The other change is to fix what I believe is an error in the checksum endpoint argument. Using `type=list` in argparse causes the endpoint to split a string into a sequence of letters e.g `--endpoint ATLAS` will cause it to look for `["A", "T", "L", "A", "S"]` endpoints. Using `nargs="+"`  should be a correct way to have a variable number of strings for endpoints.

I also added `required=True` to the checksum arguments that are labelled as required. Which will basically just cause argparse itself to error at you first if you miss an argument.